### PR TITLE
Google Drive Service Account bug fix

### DIFF
--- a/connectors/google_drive/service_account.mdx
+++ b/connectors/google_drive/service_account.mdx
@@ -63,7 +63,7 @@ If you'd rather use an individuals account + OAuth to access Google Drive, check
 
     7. Give this **Service Account** read-only access to Google Drive
         - Copy the `Unique ID` of the Service Account
-        - Go to the [Domain-wide Delegation page](https://admin.google.com/u/3/ac/owl/domainwidedelegation) in the Google Admin Console.
+        - Go to the [Domain-wide Delegation page](https://admin.google.com/ac/owl/domainwidedelegation) in the Google Admin Console.
         - Click `Add new`, fill in the client ID with the `Unique ID` of the Service account
         - Copy this comma separated list of scopes and pasted it into field `OAuth scopes`:
         `https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/drive.metadata.readonly,https://www.googleapis.com/auth/admin.directory.group.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly`


### PR DESCRIPTION
The URL previously embedded a user ID, which forces Google to reauth every time when accessing that domain.

Removing this ensures whatever user is logged in will work.