### PR TITLE
Update link for linear connector setup

### DIFF
--- a/admin/connectors/official/linear.mdx
+++ b/admin/connectors/official/linear.mdx
@@ -19,7 +19,7 @@ Issues are updated every **10** minutes.
 
 <Steps>
   <Step title="Create Linear application">
-    [Create a Linear Application.](https://linear.app/settings/api/applications/new)
+    [Create a Linear Application.](https://linear.app/settings/api)
     This step must be completed by an admin of the Linear workspace you wish to connect to Onyx.
     The application callback URLs should include `<your onyx host>/connector/oauth/callback/linear`. For example,
     for a local deployment with default configurations one of the lines should be

--- a/admin/connectors/official/linear.mdx
+++ b/admin/connectors/official/linear.mdx
@@ -19,7 +19,7 @@ Issues are updated every **10** minutes.
 
 <Steps>
   <Step title="Create Linear application">
-    [Create a Linear Application.](https://linear.app/settings/api)
+    [Create a Linear OAuth Application.](https://linear.app/settings/api)
     This step must be completed by an admin of the Linear workspace you wish to connect to Onyx.
     The application callback URLs should include `<your onyx host>/connector/oauth/callback/linear`. For example,
     for a local deployment with default configurations one of the lines should be


### PR DESCRIPTION
They moved the location of oauth applications