### PR TITLE
docs(sharepoint): add Sites.FullControl.All requirement to client-secret setup

### DIFF
--- a/admins/connectors/official/sharepoint/client-secret.mdx
+++ b/admins/connectors/official/sharepoint/client-secret.mdx
@@ -65,25 +65,26 @@ More detailed instructions can be found following the video below.
 
 ### Step 3: Configure API Permissions
 
+Two separate API permissions are required:
+
+| Permission | Provider | Type | Purpose |
+|---|---|---|---|
+| `Sites.Read.All` | Microsoft Graph | Application | Read documents and site pages |
+| `Sites.FullControl.All` | SharePoint | Application | Read document role assignments during pruning |
+
+<Note>
+  Despite its name, `Sites.FullControl.All` is read-only in Onyx. No write operations are performed.
+</Note>
+
 <Steps>
   <Step title="Open API Permissions">
     Navigate to the "API Permissions" tab in the Azure Portal.
   </Step>
 
-  <Step title="Add permission">
-    Click **Add a permission**.
-  </Step>
+  <Step title="Add Microsoft Graph permission">
+    Click **Add a permission** → **Microsoft Graph** → **Application permissions**.
 
-  <Step title="Choose Microsoft Graph">
-    Click **Microsoft Graph**, then click on **Application permissions**.
-  </Step>
-
-  <Step title="Select Sites permissions">
-    Navigate to the "Sites" permission group.
-  </Step>
-
-  <Step title="Select scope">
-    Select the checkbox for **Sites.Read.All**.
+    Navigate to the "Sites" permission group and select **Sites.Read.All**.
     - *Advanced:* If you want to limit the sites this app has access to, select **Sites.Selected**.
     However, if you do this, you will need to add the App you are currently registering to each site you want to index.
 
@@ -152,11 +153,20 @@ More detailed instructions can be found following the video below.
 
       Repeat steps 3–5 for each site you want to index.
     </Accordion>
+
+    Click **Add permissions**.
   </Step>
 
-  <Step title="Add and grant">
-    Click **Add permissions**. Finally,
-    click **Grant admin consent for \<Organization name\>** (located next to **Add a permission**)
+  <Step title="Add SharePoint permission">
+    Click **Add a permission** again → **SharePoint** → **Application permissions**.
+
+    Navigate to the "Sites" permission group and select **Sites.FullControl.All**.
+
+    Click **Add permissions**.
+  </Step>
+
+  <Step title="Grant admin consent">
+    Click **Grant admin consent for \<Organization name\>** (located next to **Add a permission**)
     and click **Confirm**.
   </Step>
 </Steps>


### PR DESCRIPTION
The client-secret connector setup guide was missing the SharePoint Sites.FullControl.All application permission, which is required  for reading document role assignments during pruning. Without it, pruning tasks fail with a 401/403.

Changes:
- Added a summary table at the top of Step 3 listing both required permissions (Sites.Read.All via Microsoft Graph,
  Sites.FullControl.All via SharePoint) with their purpose
- Split the single "Add permission" step into two clearly distinct steps — one per permission provider — so users can't miss the SharePoint permission
- Added a note clarifying that Sites.FullControl.All is read-only in Onyx

https://github.com/onyx-dot-app/onyx/pull/10397
https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
<img width="856" height="240" alt="Screenshot 2026-04-20 at 4 46 28 PM" src="https://github.com/user-attachments/assets/741ad6b4-b598-4842-a16d-6bd0c702d4b2" />
<img width="760" height="758" alt="Screenshot 2026-04-20 at 4 46 21 PM" src="https://github.com/user-attachments/assets/ad7f9880-a407-4b6f-9867-c9db23770a29" />
