### PR TITLE
feat: documentation for scope overrides

### DIFF
--- a/deployment/authentication/oauth.mdx
+++ b/deployment/authentication/oauth.mdx
@@ -118,3 +118,33 @@ providing a seamless login experience through existing Google accounts.
     ```
   </Step>
 </Steps>
+
+## Customizing requested scopes
+
+By default, Onyx requests `openid`, `email`, and `profile` from Google during
+login — the minimum needed to identify the user. You can override this list
+with `GOOGLE_OAUTH_SCOPE_OVERRIDE`, a comma-separated list of scopes to request
+instead. This is primarily useful when the access token issued at login should
+be passed through to tool calls that need additional Google API access.
+
+```bash .env
+GOOGLE_OAUTH_SCOPE_OVERRIDE=openid,email,profile,https://www.googleapis.com/auth/drive.readonly
+```
+
+<Warning>
+  The override **replaces** the default scopes — make sure `openid`, `email`,
+  and `profile` are still included if you want standard login to keep working.
+</Warning>
+
+<Note>
+  Any scopes you add here must also be enabled on the OAuth client in Google
+  Cloud Console (consent screen + client configuration). Onyx only changes
+  what is sent in the authorize request; Google still rejects scopes that are
+  not configured for the client.
+</Note>
+
+<Note>
+  These scopes apply only to the **app login** and pass-through OAuth flows.
+  The Google Drive and Gmail **connectors** use their own scopes and OAuth 
+  flow, which are not affected by this setting.
+</Note>

--- a/deployment/authentication/oidc.mdx
+++ b/deployment/authentication/oidc.mdx
@@ -79,3 +79,38 @@ Please contact us if you need help with a different identity provider.
       ```
   </Step>
 </Steps>
+
+## Customizing requested scopes
+
+By default, Onyx uses the standard OIDC base scopes when redirecting users to
+the identity provider. You can override this list with `OIDC_SCOPE_OVERRIDE`,
+a comma-separated list of scopes to request instead. This is primarily useful
+when the access token issued at login should be passed through to tool calls
+that need additional scopes from the identity provider.
+
+```bash .env
+OIDC_SCOPE_OVERRIDE=openid,email,profile,groups
+```
+
+Onyx will always also request `offline_access` so refresh tokens are issued,
+even if it is not in the override list.
+
+<Warning>
+  The override **replaces** the default scopes — make sure `openid`, `email`,
+  and `profile` are still included if you want standard login to keep working.
+</Warning>
+
+<Note>
+  Any scopes you add here must also be enabled on the application in your
+  identity provider. Onyx only changes what is sent in the authorize request;
+  the IdP still rejects scopes that are not configured for the client.
+</Note>
+
+## Enabling PKCE
+
+PKCE is disabled by default to preserve backwards compatibility with existing
+OIDC deployments. To enable it, set:
+
+```bash .env
+OIDC_PKCE_ENABLED=true
+```

--- a/deployment/configuration/configuration.mdx
+++ b/deployment/configuration/configuration.mdx
@@ -305,6 +305,21 @@ LANGFUSE_BASE_URL="https://cloud.langfuse.com" # Or "https://us.cloud.langfuse.c
     `OAUTH_CLIENT_SECRET`: For both Google OAuth and OIDC.
 
     `OPENID_CONFIG_URL`: For OIDC.
+
+    `GOOGLE_OAUTH_SCOPE_OVERRIDE`: For Google OAuth login (`AUTH_TYPE=google_oauth`
+    or `cloud`). Comma-separated list of scopes to request from Google instead
+    of the defaults (`openid,email,profile`). Useful when the access token from
+    login needs to be passed through to tool calls that require additional
+    Google API scopes (i.e. when using Pass-Through OAuth for an MCP server). 
+    Any scopes added here must also be enabled on the OAuth client in Google 
+    Cloud Console.
+
+    `OIDC_SCOPE_OVERRIDE`: For OIDC login (`AUTH_TYPE=oidc`). Comma-separated
+    list of scopes to request from the OIDC provider instead of the defaults.
+    Same use case as `GOOGLE_OAUTH_SCOPE_OVERRIDE`.
+
+    `OIDC_PKCE_ENABLED`: For OIDC login. Set to `true` to enable PKCE in the
+    OIDC login flow. Disabled by default for backwards compatibility.
   </Accordion>
 
   <Accordion title="Email Configuration">


### PR DESCRIPTION
Documenting the ways in which we allow users to override the scopes google_oauth and oidc request from the Idp