### PR TITLE
docs(hooks): document push skips initial and full re-index

### DIFF
--- a/admins/advanced_configs/hook_extensions.mdx
+++ b/admins/advanced_configs/hook_extensions.mdx
@@ -414,7 +414,8 @@ this hook fires **after** the document has been written to the index.
 The response body is not used — any `2xx` response is treated as success.
 
 <Note>
-  Document Push only fires for **public connectors** in **single-tenant** deployments.
+  Document Push only fires for **public connectors** in **single-tenant** deployments,
+  and only during **incremental syncs** — it does not fire during an initial index or a full re-index from the beginning.
 </Note>
 
 | Setting | Value |

--- a/admins/advanced_configs/hook_extensions.mdx
+++ b/admins/advanced_configs/hook_extensions.mdx
@@ -415,7 +415,8 @@ The response body is not used — any `2xx` response is treated as success.
 
 <Note>
   Document Push only fires for **public connectors** in **single-tenant** deployments,
-  and only during **incremental syncs** — it does not fire during an initial index or a full re-index from the beginning.
+  and only during **incremental syncs** — it does not fire during an initial index or a full re-index from the
+  beginning.
 </Note>
 
 | Setting | Value |


### PR DESCRIPTION
## Description

Updates the Document Push hook docs to note that it does not fire during an initial index or a full re-index from the beginning — only incremental syncs.

## Related

onyx-dot-app/onyx#11248