### PR TITLE
docs: add Atomic Chat as local OpenAI-compatible provider

### DIFF
--- a/admins/ai_models/atomic_chat.mdx
+++ b/admins/ai_models/atomic_chat.mdx
@@ -1,0 +1,61 @@
+---
+title: "Atomic Chat"
+description: "Using Atomic Chat with Onyx"
+icon: "message"
+---
+
+import NavigateToAiModels from "/snippets/navigate-to-ai-models.mdx";
+
+## Guide
+
+Configure Onyx to use models served locally by [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat).
+
+Atomic Chat exposes an **OpenAI-compatible API** at `http://localhost:1337/v1`. Load a model in the Atomic Chat app, then connect Onyx through a custom OpenAI-compatible provider.
+
+<Steps>
+  <Step title="Start Atomic Chat and load a model">
+    Download Atomic Chat from the [releases page](https://github.com/AtomicBot-ai/Atomic-Chat/releases) or [atomic.chat](https://atomic.chat/).
+
+    Open the app and load the model you want to use. The local API server starts automatically on port `1337`.
+
+    Verify the server is running:
+
+    ```bash
+    curl http://127.0.0.1:1337/v1/models
+    ```
+
+    <Info>
+      **Running Onyx in Docker on the same machine as Atomic Chat?**
+
+      Use `http://host.docker.internal:1337/v1` as the **Base URL** instead of `http://localhost:1337/v1`.
+      Inside a container, `localhost` refers to the container itself, not your host.
+    </Info>
+  </Step>
+
+  <NavigateToAiModels />
+
+  <Step title="Add a custom OpenAI-compatible provider">
+    Select **Add Custom LLM Provider** from the available providers.
+
+    Give your provider a **Display Name** (for example, `Atomic Chat`).
+
+    Set **Provider Name** to `openai`. Atomic Chat implements the OpenAI API surface that LiteLLM expects for chat completions.
+
+    Set **Base URL** to `http://127.0.0.1:1337/v1` (or `http://host.docker.internal:1337/v1` if Onyx runs in Docker).
+
+    If Atomic Chat requires an API key in your setup, enter any non-empty placeholder such as `atomic`.
+  </Step>
+
+  <Step title="Configure models">
+    In **Model Configurations**, add the model name exactly as shown in Atomic Chat (for example, the loaded GGUF or Hugging Face model ID).
+
+    Click **Fetch Available Models** if your Onyx version supports discovery against OpenAI-compatible `/models` endpoints.
+
+    Choose which models are visible to your users and whether the provider is public or private.
+  </Step>
+</Steps>
+
+## Related resources
+
+- [Atomic Chat API docs](https://github.com/AtomicBot-ai/Atomic-Chat#-use-it-as-an-api)
+- [Custom Inference Provider](/admins/ai_models/custom_inference_provider) for other OpenAI-compatible gateways

--- a/admins/ai_models/overview.mdx
+++ b/admins/ai_models/overview.mdx
@@ -41,8 +41,8 @@ which models are visible, and which models should be the default or fast option 
   <Accordion title="Self-Hosted and Local Runtimes" icon="desktop">
     These options let you run open-weight models on your own infrastructure or local hardware.
 
-    Onyx includes built-in integrations for [Ollama](/admins/ai_models/ollama),
-    [LM Studio](/admins/ai_models/lm_studio), and [Atomic Chat](/admins/ai_models/atomic_chat). This is a good fit when your team needs local development workflows,
+    Onyx includes built-in integrations for [Ollama](/admins/ai_models/ollama)
+    and [LM Studio](/admins/ai_models/lm_studio). You can also connect [Atomic Chat](/admins/ai_models/atomic_chat) and other local runtimes through an OpenAI-compatible endpoint. This is a good fit when your team needs local development workflows,
     tighter data residency, or lower per-token costs.
   </Accordion>
 

--- a/admins/ai_models/overview.mdx
+++ b/admins/ai_models/overview.mdx
@@ -41,8 +41,8 @@ which models are visible, and which models should be the default or fast option 
   <Accordion title="Self-Hosted and Local Runtimes" icon="desktop">
     These options let you run open-weight models on your own infrastructure or local hardware.
 
-    Onyx includes built-in integrations for [Ollama](/admins/ai_models/ollama)
-    and [LM Studio](/admins/ai_models/lm_studio). This is a good fit when your team needs local development workflows,
+    Onyx includes built-in integrations for [Ollama](/admins/ai_models/ollama),
+    [LM Studio](/admins/ai_models/lm_studio), and [Atomic Chat](/admins/ai_models/atomic_chat). This is a good fit when your team needs local development workflows,
     tighter data residency, or lower per-token costs.
   </Accordion>
 
@@ -98,6 +98,8 @@ which models are visible, and which models should be the default or fast option 
   <Card title="Ollama" icon="robot" href="/admins/ai_models/ollama"/>
 
   <Card title="LM Studio" icon="desktop" href="/admins/ai_models/lm_studio"/>
+
+  <Card title="Atomic Chat" icon="message" href="/admins/ai_models/atomic_chat"/>
 
   <Card title="OpenAI-Compatible Providers" icon="server" href="/admins/ai_models/custom_inference_provider"/>
 </Columns>

--- a/docs.json
+++ b/docs.json
@@ -152,6 +152,7 @@
                   "admins/ai_models/anthropic",
                   "admins/ai_models/ollama",
                   "admins/ai_models/lm_studio",
+                  "admins/ai_models/atomic_chat",
                   "admins/ai_models/azure_openai",
                   "admins/ai_models/bedrock",
                   "admins/ai_models/google_ai",


### PR DESCRIPTION
## Summary
- Add admin guide at `admins/ai_models/atomic_chat.mdx`
- Link from AI models overview and navigation

Atomic Chat exposes `http://localhost:1337/v1` for local inference. The guide walks admins through the custom OpenAI-compatible provider setup, including Docker networking notes.

## Test plan
- [ ] Mintlify preview renders the new page
- [ ] Links from overview resolve correctly

Made with [Cursor](https://cursor.com)