### PR TITLE
docs(admins): add Tracing setup guide (Braintrust / Langfuse)

### DIFF
--- a/admins/advanced_configs/tracing.mdx
+++ b/admins/advanced_configs/tracing.mdx
@@ -4,9 +4,9 @@ description: "Send LLM call traces to observability platforms to monitor and eva
 icon: "chart-line"
 ---
 
-Tracing forwards every LLM call Onyx makes to an external observability platform so you can
-monitor latency, token usage, and cost, and evaluate response quality. Onyx supports
-[Braintrust](https://www.braintrust.dev) and [Langfuse](https://langfuse.com).
+Tracing forwards every LLM call Onyx makes to an external observability platform so you can monitor latency,
+token usage, and cost, and evaluate response quality. Onyx supports [Braintrust](https://www.braintrust.dev)
+and [Langfuse](https://langfuse.com).
 
 <Note>
   Tracing is available on **self-hosted** deployments. It is not configurable on Onyx Cloud.
@@ -16,8 +16,8 @@ monitor latency, token usage, and cost, and evaluate response quality. Onyx supp
 
 <Steps>
   <Step title="Navigate to the Tracing dashboard">
-    Click your user profile icon, select **Admin Panel**, and open the **Tracing** tab under
-    the **Usage** section of the sidebar.
+    Click your user profile icon, select **Admin Panel**,
+    and open the **Tracing** tab under the **Usage** section of the sidebar.
   </Step>
 
   <Step title="Connect Braintrust and/or Langfuse">
@@ -25,47 +25,44 @@ monitor latency, token usage, and cost, and evaluate response quality. Onyx supp
 
     <Tabs tabs={["Braintrust", "Langfuse"]}>
       <Tab title="Braintrust">
-        Create an API key in the [Braintrust dashboard](https://www.braintrust.dev/app) under
-        **Settings → API Keys**.
+        Create an API key in the [Braintrust dashboard](https://www.braintrust.dev/app) under **Settings → API Keys**.
 
         In Onyx, click **Connect** on the Braintrust card and fill in:
 
         - **API Key** — your Braintrust API key.
         - **Project Name** *(optional)* — the Braintrust project traces are logged to. Defaults
-          to `Onyx`.
+        to `Onyx`.
         - **API URL** *(optional)* — only needed for self-hosted Braintrust or non-default
-          regions. Defaults to `https://api.braintrust.dev`.
+        regions. Defaults to `https://api.braintrust.dev`.
       </Tab>
 
       <Tab title="Langfuse">
-        Create a key pair in your [Langfuse](https://cloud.langfuse.com) project settings under
-        **Setup → API Keys**.
+        Create a key pair in your [Langfuse](https://cloud.langfuse.com) project settings under **Setup → API Keys**.
 
         In Onyx, click **Connect** on the Langfuse card and fill in:
 
         - **Secret Key** — your Langfuse secret key (`sk-...`).
         - **Public Key** — your Langfuse public key (`pk-...`).
         - **API Base URL** *(optional)* — defaults to the EU region
-          (`https://cloud.langfuse.com`). Set this for the US region, another region, or a
-          self-hosted Langfuse instance.
+        (`https://cloud.langfuse.com`). Set this for the US region, another region, or a self-hosted Langfuse instance.
       </Tab>
     </Tabs>
 
-    Onyx validates the credentials before saving. Once connected, the card shows **Connected**
-    and traces begin flowing within about 30 seconds — no restart required.
+    Onyx validates the credentials before saving. Once connected,
+    the card shows **Connected** and traces begin flowing within about 30 seconds — no restart required.
   </Step>
 </Steps>
 
 ## Disconnect a provider
 
-Open the provider card, click the disconnect button, and confirm. Onyx stops sending new traces
-to that provider immediately. Traces already delivered are unaffected.
+Open the provider card, click the disconnect button, and confirm.
+Onyx stops sending new traces to that provider immediately. Traces already delivered are unaffected.
 
 ## Configuring with environment variables
 
-Configuring tracing from the Admin Panel is the recommended approach, but Onyx also honors
-environment variables for backwards compatibility. A provider configured through the UI takes
-precedence over its environment variables.
+Configuring tracing from the Admin Panel is the recommended approach,
+but Onyx also honors environment variables for backwards compatibility.
+A provider configured through the UI takes precedence over its environment variables.
 
 | Provider | Variable | Description |
 | --- | --- | --- |
@@ -77,7 +74,6 @@ precedence over its environment variables.
 | Langfuse | `LANGFUSE_HOST` | Base URL for a non-default region or self-hosted Langfuse. |
 
 <Note>
-  Providers configured through environment variables appear in the Tracing dashboard as
-  configured via environment. You can adopt them into UI-managed configuration by connecting the
-  provider from the Admin Panel.
+  Providers configured through environment variables appear in the Tracing dashboard as configured via environment.
+  You can adopt them into UI-managed configuration by connecting the provider from the Admin Panel.
 </Note>

--- a/admins/advanced_configs/tracing.mdx
+++ b/admins/advanced_configs/tracing.mdx
@@ -1,0 +1,83 @@
+---
+title: "Tracing"
+description: "Send LLM call traces to observability platforms to monitor and evaluate your Onyx deployment"
+icon: "chart-line"
+---
+
+Tracing forwards every LLM call Onyx makes to an external observability platform so you can
+monitor latency, token usage, and cost, and evaluate response quality. Onyx supports
+[Braintrust](https://www.braintrust.dev) and [Langfuse](https://langfuse.com).
+
+<Note>
+  Tracing is available on **self-hosted** deployments. It is not configurable on Onyx Cloud.
+</Note>
+
+## Connect a provider
+
+<Steps>
+  <Step title="Navigate to the Tracing dashboard">
+    Click your user profile icon, select **Admin Panel**, and open the **Tracing** tab under
+    the **Usage** section of the sidebar.
+  </Step>
+
+  <Step title="Connect Braintrust and/or Langfuse">
+    You can connect either or both providers — traces are sent to every connected provider.
+
+    <Tabs tabs={["Braintrust", "Langfuse"]}>
+      <Tab title="Braintrust">
+        Create an API key in the [Braintrust dashboard](https://www.braintrust.dev/app) under
+        **Settings → API Keys**.
+
+        In Onyx, click **Connect** on the Braintrust card and fill in:
+
+        - **API Key** — your Braintrust API key.
+        - **Project Name** *(optional)* — the Braintrust project traces are logged to. Defaults
+          to `Onyx`.
+        - **API URL** *(optional)* — only needed for self-hosted Braintrust or non-default
+          regions. Defaults to `https://api.braintrust.dev`.
+      </Tab>
+
+      <Tab title="Langfuse">
+        Create a key pair in your [Langfuse](https://cloud.langfuse.com) project settings under
+        **Setup → API Keys**.
+
+        In Onyx, click **Connect** on the Langfuse card and fill in:
+
+        - **Secret Key** — your Langfuse secret key (`sk-...`).
+        - **Public Key** — your Langfuse public key (`pk-...`).
+        - **API Base URL** *(optional)* — defaults to the EU region
+          (`https://cloud.langfuse.com`). Set this for the US region, another region, or a
+          self-hosted Langfuse instance.
+      </Tab>
+    </Tabs>
+
+    Onyx validates the credentials before saving. Once connected, the card shows **Connected**
+    and traces begin flowing within about 30 seconds — no restart required.
+  </Step>
+</Steps>
+
+## Disconnect a provider
+
+Open the provider card, click the disconnect button, and confirm. Onyx stops sending new traces
+to that provider immediately. Traces already delivered are unaffected.
+
+## Configuring with environment variables
+
+Configuring tracing from the Admin Panel is the recommended approach, but Onyx also honors
+environment variables for backwards compatibility. A provider configured through the UI takes
+precedence over its environment variables.
+
+| Provider | Variable | Description |
+| --- | --- | --- |
+| Braintrust | `BRAINTRUST_API_KEY` | API key. Enables Braintrust tracing when set. |
+| Braintrust | `BRAINTRUST_PROJECT` | Project name traces are logged to. Defaults to `Onyx`. |
+| Braintrust | `BRAINTRUST_API_URL` | Custom API URL for self-hosted / non-default regions. |
+| Langfuse | `LANGFUSE_SECRET_KEY` | Secret key. Required (with the public key) to enable Langfuse. |
+| Langfuse | `LANGFUSE_PUBLIC_KEY` | Public key. Required (with the secret key) to enable Langfuse. |
+| Langfuse | `LANGFUSE_HOST` | Base URL for a non-default region or self-hosted Langfuse. |
+
+<Note>
+  Providers configured through environment variables appear in the Tracing dashboard as
+  configured via environment. You can adopt them into UI-managed configuration by connecting the
+  provider from the Admin Panel.
+</Note>

--- a/docs.json
+++ b/docs.json
@@ -296,6 +296,7 @@
               "admins/advanced_configs/white_labeling",
               "admins/advanced_configs/llm_access_controls",
               "admins/advanced_configs/hook_extensions",
+              "admins/advanced_configs/tracing",
               "admins/getting_started/slack_bot_setup",
               "admins/miscellaneous/discord_bot"
             ]


### PR DESCRIPTION
## Description

Adds a customer-facing setup guide for **Tracing** — connecting Braintrust / Langfuse to send LLM call traces from a self-hosted Onyx deployment for monitoring and evaluation.

Documents the corresponding feature PRs in `onyx-dot-app/onyx` (#12529, #12535, #12539).

- New page: `admins/advanced_configs/tracing.mdx` (under **Advanced Configs**).
- Covers: connecting each provider from Admin Panel → Usage → Tracing (with where to get keys, optional project/region/base-URL fields), disconnecting, and the environment-variable equivalents for backwards compatibility.
- Notes it's self-hosted only (not configurable on Onyx Cloud) and that UI changes apply within ~30s without a restart.

## Notes

- Text-only for now (no screenshots) — happy to add dashboard images (matching the Web Search page style) if wanted.
- Placed under Advanced Configs alongside `hook_extensions`; can move to Auditing/Analytics if that's preferred.