### PR TITLE
docs(admins): add DaoXE OpenAI-compatible LLM gateway guide

### DIFF
--- a/admins/ai_models/custom_inference_provider.mdx
+++ b/admins/ai_models/custom_inference_provider.mdx
@@ -15,6 +15,12 @@ you can configure a custom inference provider.
   Your custom provider must provide OpenAI-compatible API endpoints.
 </Tip>
 
+<Note>
+  For a hosted multi-model gateway example that uses Onyx's built-in
+  **OpenAI-Compatible** card (API base + key + fetch models), see
+  [DaoXE](/admins/ai_models/daoxe).
+</Note>
+
 <Steps>
   <Step title="Setup your Custom Inference Provider">
     Determine your provider's API base URL.

--- a/admins/ai_models/daoxe.mdx
+++ b/admins/ai_models/daoxe.mdx
@@ -1,0 +1,89 @@
+---
+title: "DaoXE"
+description: "Configure DaoXE as an OpenAI-compatible multi-model gateway for Onyx"
+icon: "server"
+---
+
+import NavigateToAiModels from "/snippets/navigate-to-ai-models.mdx";
+import StandardAiModelConfigs from "/snippets/standard-ai-model-configs.mdx";
+
+## Guide
+
+Configure Onyx to use models served through [DaoXE](https://daoxe.com), a multi-model,
+multi-protocol API gateway.
+
+Onyx talks to DaoXE over the **OpenAI-compatible** path (Chat Completions and
+`/v1/models`). DaoXE also exposes other client protocols outside Onyx — including
+OpenAI Responses and Anthropic Messages — so the same account can serve different
+tools; this page only covers the Onyx admin setup.
+
+<Note>
+  DaoXE model IDs are **account-scoped** and change over time. Prefer **Fetch Available
+  Models** in the Onyx UI (or copy IDs from your DaoXE account catalog). Do not hardcode a
+  static public model list.
+</Note>
+
+<Tip>
+  DaoXE is not a built-in Onyx provider card. Use **OpenAI-Compatible** under
+  **Self-hosted & Custom** and point the API base at DaoXE.
+</Tip>
+
+<Steps>
+  <Step title="Create a DaoXE API key">
+    Sign in at [daoxe.com](https://daoxe.com) and create an API key for your workspace.
+
+    Confirm which chat models are visible in your account catalog. Those model IDs are
+    what Onyx will call after import.
+
+    <Note>
+      DaoXE does not serve mainland China. If `https://daoxe.com` is unreachable from your
+      network, use the regional endpoint documented on the DaoXE site rather than guessing
+      an alternate host.
+    </Note>
+  </Step>
+
+  <NavigateToAiModels />
+
+  <Step title="Add DaoXE as OpenAI-Compatible">
+    Under **Self-hosted & Custom**, select **OpenAI-Compatible**.
+
+    Give the provider a **Display Name** (for example, `DaoXE`).
+
+    Set **API Base URL** to:
+
+    ```text
+    https://daoxe.com/v1
+    ```
+
+    Paste your DaoXE **API Key**.
+
+    Click **Fetch Available Models** so Onyx can load the language models currently
+    exposed by your DaoXE account.
+  </Step>
+
+  <Step title="Review imported model IDs">
+    Onyx stores the model IDs returned by DaoXE's OpenAI-compatible `/v1/models` endpoint
+    and makes those models available to users you grant access to.
+
+    Keep the visible set small: pick the chat models you actually want for agents and
+    RAG rather than every ID in the catalog.
+
+    <Info>
+      For graph extraction, tool calling, or long agent loops, prefer higher-capability
+      chat models from your DaoXE catalog. Smaller models may work for simple chat but can
+      be less reliable on structured outputs.
+    </Info>
+  </Step>
+
+  <StandardAiModelConfigs />
+</Steps>
+
+## Notes
+
+- **Base URL:** use `https://daoxe.com/v1` (include the `/v1` suffix).
+- **Auth:** `Authorization: Bearer <DAOXE_API_KEY>`.
+- **Protocols:** Onyx uses OpenAI-compatible Chat Completions through this integration.
+  DaoXE separately supports OpenAI Responses and Anthropic Messages for other clients;
+  configure those outside Onyx when needed.
+- **Examples:** OpenAI SDK samples for DaoXE live at
+  [seven7763/DaoXE-AI](https://github.com/seven7763/DaoXE-AI).

--- a/admins/ai_models/overview.mdx
+++ b/admins/ai_models/overview.mdx
@@ -34,7 +34,8 @@ which models are visible, and which models should be the default or fast option 
     These providers expose language models through a broader cloud or routing layer.
 
     Common choices include **Azure OpenAI**, **Amazon Bedrock**, **Google Vertex AI**, **OpenRouter**,
-    **LiteLLM Proxy**, and **Bifrost**. They are useful when you need enterprise controls, cloud alignment,
+    **LiteLLM Proxy**, **Bifrost**, and hosted multi-model gateways such as **DaoXE** (via the
+    OpenAI-Compatible provider). They are useful when you need enterprise controls, cloud alignment,
     regional hosting options, or access to multiple model families from one integration point.
   </Accordion>
 
@@ -65,8 +66,9 @@ which models are visible, and which models should be the default or fast option 
 - Start with one primary provider for most users.
 - Use a recent **GPT**, **Claude**,
   or **Gemini** family model as your default if you want the strongest out-of-the-box experience.
-- Use **Bedrock**, **Vertex AI**, **Azure OpenAI**, **OpenRouter**, **LiteLLM Proxy**, or **Bifrost** when procurement,
-  routing, or cloud alignment matters more than a direct vendor integration.
+- Use **Bedrock**, **Vertex AI**, **Azure OpenAI**, **OpenRouter**, **LiteLLM Proxy**, **Bifrost**, or an
+  OpenAI-compatible gateway such as [DaoXE](/admins/ai_models/daoxe) when procurement, routing, or cloud
+  alignment matters more than a direct vendor integration.
 - Use open-weight families such as **Llama**, **Qwen**, **DeepSeek**, or **gpt-oss** if you are self-hosting.
 - Keep the visible model list short so users are choosing between a few intentional options instead of every possible
   version.
@@ -94,6 +96,8 @@ which models are visible, and which models should be the default or fast option 
   <Card title="Bifrost" icon="server" href="/admins/ai_models/bifrost"/>
 
   <Card title="LiteLLM Proxy" icon="server" href="/admins/ai_models/litellm_proxy"/>
+
+  <Card title="DaoXE" icon="server" href="/admins/ai_models/daoxe"/>
 
   <Card title="Ollama" icon="robot" href="/admins/ai_models/ollama"/>
 

--- a/docs.json
+++ b/docs.json
@@ -176,6 +176,7 @@
                   "admins/ai_models/openrouter",
                   "admins/ai_models/bifrost",
                   "admins/ai_models/litellm_proxy",
+                  "admins/ai_models/daoxe",
                   "admins/ai_models/custom_inference_provider"
                 ]
               }


### PR DESCRIPTION
## Description

Adds an admin guide for configuring **[DaoXE](https://daoxe.com)** as an OpenAI-compatible multi-model gateway in Onyx.

DaoXE is not a first-party Onyx provider card. The guide walks through the existing **OpenAI-Compatible** path under **Self-hosted & Custom**:

- API base: `https://daoxe.com/v1`
- Bearer API key from the DaoXE account
- **Fetch Available Models** (account-scoped model IDs — no hardcoded public catalog)
- Multi-protocol note: Onyx uses Chat Completions here; DaoXE also exposes OpenAI Responses and Anthropic Messages for other clients
- Mainland China unavailability + use site-documented regional endpoint if needed

Also links DaoXE from the Language Models overview and the generic custom-provider page, and registers the page in `docs.json`.

## Notes

- Docs-only; no product/code changes in `onyx-dot-app/onyx`
- I maintain DaoXE. OpenAI SDK examples: https://github.com/seven7763/DaoXE-AI
- Pattern matches existing gateway pages (OpenRouter / Bifrost / LiteLLM Proxy) while correctly using the OpenAI-Compatible UI card

## Checklist

- [x] Page under `admins/ai_models/`
- [x] Nav entry in `docs.json`
- [x] Overview card + cross-link from custom inference provider
- [x] No secrets or hardcoded model ID / price tables