### PR TITLE
docs(skills): document skill creation workflows

### DIFF
--- a/admins/managing_features/craft_apps.mdx
+++ b/admins/managing_features/craft_apps.mdx
@@ -290,25 +290,25 @@ Disable them when they should not be available.
     Check whether the provider's consent screen is limited to approved test users or workspace members.
   </Accordion>
 
-<Accordion title="An enabled App does not appear to users">
-  Confirm that its card says **Enabled** and that the user has Craft access. Refresh the Apps page. For a custom App,
-  confirm its bundle and configuration saved successfully.
-</Accordion>
+  <Accordion title="An enabled App does not appear to users">
+    Confirm that its card says **Enabled** and that the user has Craft access. Refresh the Apps page. For a custom App,
+    confirm its bundle and configuration saved successfully.
+  </Accordion>
 
-<Accordion title="A user connected successfully but an action is blocked">
-  Check the action's admin policy and the scopes or capabilities granted by the external account.
-  A Deny policy cannot be overridden. An Ask request can also fail if the user rejects it or the approval expires.
-</Accordion>
+  <Accordion title="A user connected successfully but an action is blocked">
+    Check the action's admin policy and the scopes or capabilities granted by the external account.
+    A Deny policy cannot be overridden. An Ask request can also fail if the user rejects it or the approval expires.
+  </Accordion>
 
-<Accordion title="A custom App prompts for every request">
-  This is expected. Custom Apps use one synthesized Ask action for every request matching their URL patterns.
-  They do not currently support per-action policies.
-</Accordion>
+  <Accordion title="A custom App prompts for every request">
+    This is expected. Custom Apps use one synthesized Ask action for every request matching their URL patterns.
+    They do not currently support per-action policies.
+  </Accordion>
 
-<Accordion title="A custom App calls the wrong service or uses the wrong credential">
-  Check for overlapping URL patterns. Make every host and path as specific as possible.
-  The lowest-ID App wins when multiple Apps match the same URL, including when that first App is disabled.
-</Accordion>
+  <Accordion title="A custom App calls the wrong service or uses the wrong credential">
+    Check for overlapping URL patterns. Make every host and path as specific as possible.
+    The lowest-ID App wins when multiple Apps match the same URL, including when that first App is disabled.
+  </Accordion>
 
   <Accordion title="A Scheduled Task is awaiting approval">
     Confirm that the task owner is still connected to the App and selected it under **Pre-approved Apps**.

--- a/admins/managing_features/craft_apps.mdx
+++ b/admins/managing_features/craft_apps.mdx
@@ -8,9 +8,8 @@ Apps give Craft controlled, authenticated access to external services.
 Admins configure Apps under **Admin Panel → Craft → Apps**. Users connect their accounts under **Craft → Apps**.
 
 <Note>
-  Craft Apps are different from Onyx connectors. A connector indexes shared
-  content into Onyx knowledge. An App retrieves live information from a user's
-  external account and can take actions in that service.
+  Craft Apps are different from Onyx connectors. A connector indexes shared content into Onyx knowledge.
+  An App retrieves live information from a user's external account and can take actions in that service.
 </Note>
 
 ## Choose the setup path
@@ -42,9 +41,8 @@ The App management form asks for the OAuth client ID and client secret;
 it does not ask for an individual user's access token.
 
 <Note>
-  On self-hosted Onyx, the callback host comes from `WEB_DOMAIN`. Confirm that
-  setting uses the public domain registered with the provider before users
-  connect.
+  On self-hosted Onyx, the callback host comes from `WEB_DOMAIN`.
+  Confirm that setting uses the public domain registered with the provider before users connect.
 </Note>
 
 <AccordionGroup>
@@ -67,49 +65,43 @@ it does not ask for an individual user's access token.
 
     Craft acts with a user token; no bot user is required.
     Copy the Client ID and Client Secret from the Slack app's basic information.
-
   </Accordion>
 
 <Accordion title="Google Calendar">
-  In Google Cloud Console, create or select a project, enable the **Google
-  Calendar API**, configure the OAuth consent screen, and create an OAuth 2.0
-  Client ID of type **Web application**. Add the Onyx redirect URI under
-  **Authorized redirect URIs**. Craft requests full Google Calendar access.
+  In Google Cloud Console, create or select a project, enable the **Google Calendar API**,
+  configure the OAuth consent screen, and create an OAuth 2.0 Client ID of type **Web application**.
+  Add the Onyx redirect URI under **Authorized redirect URIs**. Craft requests full Google Calendar access.
 </Accordion>
 
 <Accordion title="Google Drive">
-  In Google Cloud Console, enable both the **Google Drive API** and **Google
-  Docs API**, configure the OAuth consent screen, and create an OAuth 2.0 Web
-  application client with the Onyx redirect URI. Craft requests the full Drive
-  scope so it can read, create, edit, and delete files; action policies govern
-  those operations inside Craft.
+  In Google Cloud Console, enable both the **Google Drive API** and **Google Docs API**,
+  configure the OAuth consent screen, and create an OAuth 2.0 Web application client with the Onyx redirect URI.
+  Craft requests the full Drive scope so it can read, create, edit, and delete files;
+  action policies govern those operations inside Craft.
 </Accordion>
 
 <Accordion title="Gmail">
-  In Google Cloud Console, enable the **Gmail API**, configure the OAuth consent
-  screen, and create an OAuth 2.0 Web application client with the Onyx redirect
-  URI. Craft requests `gmail.modify`, which covers reading, labels, drafts,
-  trash, and sending but not permanent message deletion.
+  In Google Cloud Console, enable the **Gmail API**, configure the OAuth consent screen,
+  and create an OAuth 2.0 Web application client with the Onyx redirect URI. Craft requests `gmail.modify`,
+  which covers reading, labels, drafts, trash, and sending but not permanent message deletion.
 </Accordion>
 
 <Accordion title="Linear">
-  In Linear, open **Settings → API → OAuth applications**, create an OAuth
-  application, and add the Onyx redirect URI to its callback URLs. Craft
-  requests user-acting read and write access for issues, projects, and comments.
+  In Linear, open **Settings → API → OAuth applications**, create an OAuth application,
+  and add the Onyx redirect URI to its callback URLs. Craft requests user-acting read and write access for issues,
+  projects, and comments.
 </Accordion>
 
 <Accordion title="GitHub">
-  In GitHub, open **Settings → Developer settings → OAuth Apps**, create an
-  OAuth App, and use the Onyx redirect URI as its authorization callback URL.
-  Craft requests `repo`, `read:org`, and `read:user`; the `repo` scope includes
-  repositories the connecting user can access, including private repositories.
+  In GitHub, open **Settings → Developer settings → OAuth Apps**, create an OAuth App,
+  and use the Onyx redirect URI as its authorization callback URL. Craft requests `repo`, `read:org`, and `read:user`;
+  the `repo` scope includes repositories the connecting user can access, including private repositories.
 </Accordion>
 
 <Accordion title="HubSpot">
-  From a HubSpot developer account, create an app and add the Onyx redirect URI
-  on its **Auth** tab. Configure read access for owners, contacts, companies,
-  and deals. Contact, company, and deal write scopes are optional so read-only
-  HubSpot accounts can still connect.
+  From a HubSpot developer account, create an app and add the Onyx redirect URI on its **Auth** tab.
+  Configure read access for owners, contacts, companies, and deals. Contact, company,
+  and deal write scopes are optional so read-only HubSpot accounts can still connect.
 </Accordion>
 
   <Accordion title="Notion">
@@ -127,20 +119,20 @@ it does not ask for an individual user's access token.
     open the App configured by Onyx.
   </Step>
 
-<Step title="Enter organization credentials">
-  On self-hosted Onyx, enter the OAuth client ID and client secret from the
-  provider. On Onyx Cloud, these fields are managed by Onyx and are not shown.
-</Step>
+  <Step title="Enter organization credentials">
+    On self-hosted Onyx, enter the OAuth client ID and client secret from the provider. On Onyx Cloud,
+    these fields are managed by Onyx and are not shown.
+  </Step>
 
-<Step title="Review permissions">
-  Choose a policy for all actions, or open **Advanced** and set policies action
-  by action. Review every write, send, delete, and publish action.
-</Step>
+  <Step title="Review permissions">
+    Choose a policy for all actions, or open **Advanced** and set policies action by action. Review every write, send,
+    delete, and publish action.
+  </Step>
 
-<Step title="Enable the App">
-  Save the configuration and confirm the App card says **Enabled**. Disabled
-  Apps do not appear to users and cannot inject credentials.
-</Step>
+  <Step title="Enable the App">
+    Save the configuration and confirm the App card says **Enabled**.
+    Disabled Apps do not appear to users and cannot inject credentials.
+  </Step>
 
   <Step title="Test as a user">
     Connect a pilot user's account from **Craft → Apps**. Test a read and a representative write,
@@ -166,9 +158,8 @@ The main permissions selector applies **Auto-approve** or **Ask** to every actio
 Open **Advanced** to create a mixed policy or choose **Deny** for individual actions.
 
 <Info>
-  If one outbound request matches more than one action, the strictest matching
-  policy wins: **Deny**, then **Ask**, then **Auto-approve**. A request to a
-  built-in App that does not match a cataloged action falls back to **Ask**.
+  If one outbound request matches more than one action, the strictest matching policy wins: **Deny**, then **Ask**,
+  then **Auto-approve**. A request to a built-in App that does not match a cataloged action falls back to **Ask**.
 </Info>
 
 An in-session **Approve for session** decision applies only to matching actions in that session.
@@ -223,11 +214,10 @@ https://*.example.com/*
 ```
 
 <Warning>
-  Custom Apps cannot be used to reach private, loopback, link-local, cloud
-  metadata, or other non-public network addresses. The sandbox proxy blocks
-  internal destinations even when a URL pattern includes them. Expose only a
-  deliberately secured, publicly routable HTTPS endpoint if Craft must call a
-  custom service.
+  Custom Apps cannot be used to reach private, loopback, link-local, cloud metadata,
+  or other non-public network addresses.
+  The sandbox proxy blocks internal destinations even when a URL pattern includes them.
+  Expose only a deliberately secured, publicly routable HTTPS endpoint if Craft must call a custom service.
 </Warning>
 
 Avoid overlapping URL patterns between Apps. When more than one App claims the same URL,
@@ -274,10 +264,9 @@ for the bundle format and review checklist.
 
 <Warning>
   Custom Apps do not have a per-action catalog. For a connected custom App,
-  every request matching an upstream URL pattern is treated as an unspecified
-  **Ask** action. Admins cannot Auto-approve or Deny individual custom App
-  operations. Disable the App to stop its use, and be especially cautious when
-  users pre-approve it for a Scheduled Task.
+  every request matching an upstream URL pattern is treated as an unspecified **Ask** action.
+  Admins cannot Auto-approve or Deny individual custom App operations. Disable the App to stop its use,
+  and be especially cautious when users pre-approve it for a Scheduled Task.
 </Warning>
 
 ## Manage credentials and lifecycle
@@ -302,27 +291,23 @@ Disable them when they should not be available.
   </Accordion>
 
 <Accordion title="An enabled App does not appear to users">
-  Confirm that its card says **Enabled** and that the user has Craft access.
-  Refresh the Apps page. For a custom App, confirm its bundle and configuration
-  saved successfully.
+  Confirm that its card says **Enabled** and that the user has Craft access. Refresh the Apps page. For a custom App,
+  confirm its bundle and configuration saved successfully.
 </Accordion>
 
 <Accordion title="A user connected successfully but an action is blocked">
-  Check the action's admin policy and the scopes or capabilities granted by the
-  external account. A Deny policy cannot be overridden. An Ask request can also
-  fail if the user rejects it or the approval expires.
+  Check the action's admin policy and the scopes or capabilities granted by the external account.
+  A Deny policy cannot be overridden. An Ask request can also fail if the user rejects it or the approval expires.
 </Accordion>
 
 <Accordion title="A custom App prompts for every request">
-  This is expected. Custom Apps use one synthesized Ask action for every request
-  matching their URL patterns. They do not currently support per-action
-  policies.
+  This is expected. Custom Apps use one synthesized Ask action for every request matching their URL patterns.
+  They do not currently support per-action policies.
 </Accordion>
 
 <Accordion title="A custom App calls the wrong service or uses the wrong credential">
-  Check for overlapping URL patterns. Make every host and path as specific as
-  possible. The lowest-ID App wins when multiple Apps match the same URL,
-  including when that first App is disabled.
+  Check for overlapping URL patterns. Make every host and path as specific as possible.
+  The lowest-ID App wins when multiple Apps match the same URL, including when that first App is disabled.
 </Accordion>
 
   <Accordion title="A Scheduled Task is awaiting approval">

--- a/admins/managing_features/craft_apps.mdx
+++ b/admins/managing_features/craft_apps.mdx
@@ -8,8 +8,9 @@ Apps give Craft controlled, authenticated access to external services.
 Admins configure Apps under **Admin Panel → Craft → Apps**. Users connect their accounts under **Craft → Apps**.
 
 <Note>
-  Craft Apps are different from Onyx connectors. A connector indexes shared content into Onyx knowledge.
-  An App retrieves live information from a user's external account and can take actions in that service.
+  Craft Apps are different from Onyx connectors. A connector indexes shared
+  content into Onyx knowledge. An App retrieves live information from a user's
+  external account and can take actions in that service.
 </Note>
 
 ## Choose the setup path
@@ -41,8 +42,9 @@ The App management form asks for the OAuth client ID and client secret;
 it does not ask for an individual user's access token.
 
 <Note>
-  On self-hosted Onyx, the callback host comes from `WEB_DOMAIN`.
-  Confirm that setting uses the public domain registered with the provider before users connect.
+  On self-hosted Onyx, the callback host comes from `WEB_DOMAIN`. Confirm that
+  setting uses the public domain registered with the provider before users
+  connect.
 </Note>
 
 <AccordionGroup>
@@ -65,44 +67,50 @@ it does not ask for an individual user's access token.
 
     Craft acts with a user token; no bot user is required.
     Copy the Client ID and Client Secret from the Slack app's basic information.
+
   </Accordion>
 
-  <Accordion title="Google Calendar">
-    In Google Cloud Console, create or select a project, enable the **Google Calendar API**,
-    configure the OAuth consent screen, and create an OAuth 2.0 Client ID of type **Web application**.
-    Add the Onyx redirect URI under **Authorized redirect URIs**. Craft requests full Google Calendar access.
-  </Accordion>
+<Accordion title="Google Calendar">
+  In Google Cloud Console, create or select a project, enable the **Google
+  Calendar API**, configure the OAuth consent screen, and create an OAuth 2.0
+  Client ID of type **Web application**. Add the Onyx redirect URI under
+  **Authorized redirect URIs**. Craft requests full Google Calendar access.
+</Accordion>
 
-  <Accordion title="Google Drive">
-    In Google Cloud Console, enable both the **Google Drive API** and **Google Docs API**,
-    configure the OAuth consent screen, and create an OAuth 2.0 Web application client with the Onyx redirect URI.
-    Craft requests the full Drive scope so it can read, create, edit, and delete files;
-    action policies govern those operations inside Craft.
-  </Accordion>
+<Accordion title="Google Drive">
+  In Google Cloud Console, enable both the **Google Drive API** and **Google
+  Docs API**, configure the OAuth consent screen, and create an OAuth 2.0 Web
+  application client with the Onyx redirect URI. Craft requests the full Drive
+  scope so it can read, create, edit, and delete files; action policies govern
+  those operations inside Craft.
+</Accordion>
 
-  <Accordion title="Gmail">
-    In Google Cloud Console, enable the **Gmail API**, configure the OAuth consent screen,
-    and create an OAuth 2.0 Web application client with the Onyx redirect URI. Craft requests `gmail.modify`,
-    which covers reading, labels, drafts, trash, and sending but not permanent message deletion.
-  </Accordion>
+<Accordion title="Gmail">
+  In Google Cloud Console, enable the **Gmail API**, configure the OAuth consent
+  screen, and create an OAuth 2.0 Web application client with the Onyx redirect
+  URI. Craft requests `gmail.modify`, which covers reading, labels, drafts,
+  trash, and sending but not permanent message deletion.
+</Accordion>
 
-  <Accordion title="Linear">
-    In Linear, open **Settings → API → OAuth applications**, create an OAuth application,
-    and add the Onyx redirect URI to its callback URLs. Craft requests user-acting read and write access for issues,
-    projects, and comments.
-  </Accordion>
+<Accordion title="Linear">
+  In Linear, open **Settings → API → OAuth applications**, create an OAuth
+  application, and add the Onyx redirect URI to its callback URLs. Craft
+  requests user-acting read and write access for issues, projects, and comments.
+</Accordion>
 
-  <Accordion title="GitHub">
-    In GitHub, open **Settings → Developer settings → OAuth Apps**, create an OAuth App,
-    and use the Onyx redirect URI as its authorization callback URL. Craft requests `repo`, `read:org`, and `read:user`;
-    the `repo` scope includes repositories the connecting user can access, including private repositories.
-  </Accordion>
+<Accordion title="GitHub">
+  In GitHub, open **Settings → Developer settings → OAuth Apps**, create an
+  OAuth App, and use the Onyx redirect URI as its authorization callback URL.
+  Craft requests `repo`, `read:org`, and `read:user`; the `repo` scope includes
+  repositories the connecting user can access, including private repositories.
+</Accordion>
 
-  <Accordion title="HubSpot">
-    From a HubSpot developer account, create an app and add the Onyx redirect URI on its **Auth** tab.
-    Configure read access for owners, contacts, companies, and deals. Contact, company,
-    and deal write scopes are optional so read-only HubSpot accounts can still connect.
-  </Accordion>
+<Accordion title="HubSpot">
+  From a HubSpot developer account, create an app and add the Onyx redirect URI
+  on its **Auth** tab. Configure read access for owners, contacts, companies,
+  and deals. Contact, company, and deal write scopes are optional so read-only
+  HubSpot accounts can still connect.
+</Accordion>
 
   <Accordion title="Notion">
     Create a **Public** integration from Notion's integrations settings and add the Onyx redirect URI under **OAuth
@@ -119,20 +127,20 @@ it does not ask for an individual user's access token.
     open the App configured by Onyx.
   </Step>
 
-  <Step title="Enter organization credentials">
-    On self-hosted Onyx, enter the OAuth client ID and client secret from the provider. On Onyx Cloud,
-    these fields are managed by Onyx and are not shown.
-  </Step>
+<Step title="Enter organization credentials">
+  On self-hosted Onyx, enter the OAuth client ID and client secret from the
+  provider. On Onyx Cloud, these fields are managed by Onyx and are not shown.
+</Step>
 
-  <Step title="Review permissions">
-    Choose a policy for all actions, or open **Advanced** and set policies action by action. Review every write, send,
-    delete, and publish action.
-  </Step>
+<Step title="Review permissions">
+  Choose a policy for all actions, or open **Advanced** and set policies action
+  by action. Review every write, send, delete, and publish action.
+</Step>
 
-  <Step title="Enable the App">
-    Save the configuration and confirm the App card says **Enabled**.
-    Disabled Apps do not appear to users and cannot inject credentials.
-  </Step>
+<Step title="Enable the App">
+  Save the configuration and confirm the App card says **Enabled**. Disabled
+  Apps do not appear to users and cannot inject credentials.
+</Step>
 
   <Step title="Test as a user">
     Connect a pilot user's account from **Craft → Apps**. Test a read and a representative write,
@@ -158,8 +166,9 @@ The main permissions selector applies **Auto-approve** or **Ask** to every actio
 Open **Advanced** to create a mixed policy or choose **Deny** for individual actions.
 
 <Info>
-  If one outbound request matches more than one action, the strictest matching policy wins: **Deny**, then **Ask**,
-  then **Auto-approve**. A request to a built-in App that does not match a cataloged action falls back to **Ask**.
+  If one outbound request matches more than one action, the strictest matching
+  policy wins: **Deny**, then **Ask**, then **Auto-approve**. A request to a
+  built-in App that does not match a cataloged action falls back to **Ask**.
 </Info>
 
 An in-session **Approve for session** decision applies only to matching actions in that session.
@@ -214,10 +223,11 @@ https://*.example.com/*
 ```
 
 <Warning>
-  Custom Apps cannot be used to reach private, loopback, link-local, cloud metadata,
-  or other non-public network addresses.
-  The sandbox proxy blocks internal destinations even when a URL pattern includes them.
-  Expose only a deliberately secured, publicly routable HTTPS endpoint if Craft must call a custom service.
+  Custom Apps cannot be used to reach private, loopback, link-local, cloud
+  metadata, or other non-public network addresses. The sandbox proxy blocks
+  internal destinations even when a URL pattern includes them. Expose only a
+  deliberately secured, publicly routable HTTPS endpoint if Craft must call a
+  custom service.
 </Warning>
 
 Avoid overlapping URL patterns between Apps. When more than one App claims the same URL,
@@ -255,16 +265,19 @@ example-api.zip
     └── example_api.py
 ```
 
-The ZIP filename becomes the App slug. Put a valid `SKILL.md` at the root and review every included file.
+The ZIP filename becomes the App slug.
+Put a valid `SKILL.md` at the archive root or directly inside one enclosing folder, and review every included file.
+When you use an enclosing folder, keep every App file inside it.
 The default limits are 25 MB per extracted file and 100 MB for the complete bundle.
 See [Managing Craft Skills](/admins/managing_features/craft_skills#prepare-a-custom-skill)
 for the bundle format and review checklist.
 
 <Warning>
   Custom Apps do not have a per-action catalog. For a connected custom App,
-  every request matching an upstream URL pattern is treated as an unspecified **Ask** action.
-  Admins cannot Auto-approve or Deny individual custom App operations. Disable the App to stop its use,
-  and be especially cautious when users pre-approve it for a Scheduled Task.
+  every request matching an upstream URL pattern is treated as an unspecified
+  **Ask** action. Admins cannot Auto-approve or Deny individual custom App
+  operations. Disable the App to stop its use, and be especially cautious when
+  users pre-approve it for a Scheduled Task.
 </Warning>
 
 ## Manage credentials and lifecycle
@@ -288,25 +301,29 @@ Disable them when they should not be available.
     Check whether the provider's consent screen is limited to approved test users or workspace members.
   </Accordion>
 
-  <Accordion title="An enabled App does not appear to users">
-    Confirm that its card says **Enabled** and that the user has Craft access. Refresh the Apps page. For a custom App,
-    confirm its bundle and configuration saved successfully.
-  </Accordion>
+<Accordion title="An enabled App does not appear to users">
+  Confirm that its card says **Enabled** and that the user has Craft access.
+  Refresh the Apps page. For a custom App, confirm its bundle and configuration
+  saved successfully.
+</Accordion>
 
-  <Accordion title="A user connected successfully but an action is blocked">
-    Check the action's admin policy and the scopes or capabilities granted by the external account.
-    A Deny policy cannot be overridden. An Ask request can also fail if the user rejects it or the approval expires.
-  </Accordion>
+<Accordion title="A user connected successfully but an action is blocked">
+  Check the action's admin policy and the scopes or capabilities granted by the
+  external account. A Deny policy cannot be overridden. An Ask request can also
+  fail if the user rejects it or the approval expires.
+</Accordion>
 
-  <Accordion title="A custom App prompts for every request">
-    This is expected. Custom Apps use one synthesized Ask action for every request matching their URL patterns.
-    They do not currently support per-action policies.
-  </Accordion>
+<Accordion title="A custom App prompts for every request">
+  This is expected. Custom Apps use one synthesized Ask action for every request
+  matching their URL patterns. They do not currently support per-action
+  policies.
+</Accordion>
 
-  <Accordion title="A custom App calls the wrong service or uses the wrong credential">
-    Check for overlapping URL patterns. Make every host and path as specific as possible.
-    The lowest-ID App wins when multiple Apps match the same URL, including when that first App is disabled.
-  </Accordion>
+<Accordion title="A custom App calls the wrong service or uses the wrong credential">
+  Check for overlapping URL patterns. Make every host and path as specific as
+  possible. The lowest-ID App wins when multiple Apps match the same URL,
+  including when that first App is disabled.
+</Accordion>
 
   <Accordion title="A Scheduled Task is awaiting approval">
     Confirm that the task owner is still connected to the App and selected it under **Pre-approved Apps**.

--- a/admins/managing_features/craft_skills.mdx
+++ b/admins/managing_features/craft_skills.mdx
@@ -8,8 +8,8 @@ Skills package reusable instructions and supporting files that teach Craft how t
 Open **Craft → Skills** to review, upload, share, and manage Skills.
 
 <Note>
-  Curators can also upload Skills and manage Skills they own or can edit. Admins
-  can inspect and manage all custom Skills, including private personal Skills.
+  Curators can also upload Skills and manage Skills they own or can edit.
+  Admins can inspect and manage all custom Skills, including private personal Skills.
 </Note>
 
 ## Understand the Skills library
@@ -17,7 +17,7 @@ Open **Craft → Skills** to review, upload, share, and manage Skills.
 | Type         | Where it comes from            | What an admin can do                                                                    |
 | ------------ | ------------------------------ | --------------------------------------------------------------------------------------- |
 | **Built-in** | Shipped and maintained by Onyx | Preview its instructions and identify missing dependencies. Built-ins are not editable. |
-| **Custom**   | Uploaded by an admin or user   | Edit, share, replace files, enable or disable, transfer ownership, or delete.           |
+| **Custom**   | Created by an admin or user    | Edit, share, manage files, enable or disable, transfer ownership, or delete.             |
 
 New custom Skills start private. Share a Skill with people, groups, or the organization when others should use it.
 
@@ -35,17 +35,16 @@ Configure the missing dependency rather than uploading a custom Skill with the s
 
 ## Prepare a custom Skill
 
-Upload `SKILL.md` directly when the Skill does not need supporting files.
-For a Skill with scripts, examples, or other supporting files, create a folder with `SKILL.md` at its top level.
-Drag the folder into Onyx, or upload it as a ZIP.
+Upload `SKILL.md` directly when the Skill does not need supporting files. For a Skill with scripts, examples,
+or other supporting files, create a folder with `SKILL.md` at its top level. Drag the folder into Onyx,
+or upload it as a ZIP.
 
 <Info>
-  For a standalone `SKILL.md`, the frontmatter `name` becomes the Skill slug.
-  For a folder, the folder name becomes the slug. For a ZIP, the filename
-  without `.zip` becomes the slug. Slugs must start with a lowercase letter,
-  contain only lowercase letters, numbers, and hyphens, and be no more than 64
-  characters. They must also be unique. If an existing Skill already uses the
-  slug, replace that Skill's files or change the slug source before uploading.
+  For a standalone `SKILL.md`, Onyx creates the slug from the frontmatter `name`. For a folder,
+  the folder name becomes the slug. For a ZIP, the filename without `.zip` becomes the slug.
+  Folder and ZIP names must start with a lowercase letter, contain only lowercase letters, numbers, and hyphens,
+  and be no more than 64 characters. Slugs must be unique. If an existing Skill already uses the slug,
+  update that Skill or change the source name before uploading.
 </Info>
 
 ```text
@@ -60,8 +59,7 @@ weekly-customer-update/
 ```
 
 For a ZIP upload, put `SKILL.md` at the archive root or directly inside one enclosing folder.
-When you use an enclosing folder, keep every Skill file inside it.
-Upload only one Skill at a time.
+When you use an enclosing folder, keep every Skill file inside it. Upload only one Skill at a time.
 
 `SKILL.md` must begin with YAML frontmatter containing a non-empty name and description.
 The description should state when Craft should choose the Skill.
@@ -85,7 +83,7 @@ description: Create a weekly customer update from account activity and meeting n
 
 | Requirement         | Default                                                                                                                                     |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Slug                | Standalone frontmatter `name`, folder name, or ZIP filename without `.zip`; lowercase letters, numbers, and hyphens; maximum 64 characters. |
+| Slug                | Generated from the Skill name when written in Onyx or uploaded as `SKILL.md`; otherwise, the folder name or ZIP filename without `.zip`.     |
 | Root instructions   | One UTF-8 `SKILL.md` with valid YAML frontmatter at the Skill root.                                                                         |
 | Skills per upload   | One.                                                                                                                                        |
 | Maximum file size   | 25 MB per file in the extracted bundle.                                                                                                     |
@@ -113,32 +111,33 @@ Craft can follow scripts and commands included in the archive.
 | **Output handling**        | The Skill names the expected format and writes finished deliverables to a clear location such as `outputs/`.       |
 
 <Warning>
-  Never publish a bundle containing passwords, API keys, OAuth tokens, private
-  certificates, or production credentials. Skill files are copied into the
-  sandboxes of users who can access the Skill. Use
-  [Apps](/admins/managing_features/craft_apps) for authenticated external
-  access.
+  Never publish a bundle containing passwords, API keys, OAuth tokens, private certificates, or production credentials.
+  Skill files are copied into the sandboxes of users who can access the Skill.
+  Use [Apps](/admins/managing_features/craft_apps) for authenticated external access.
 </Warning>
 
 ## Publish a Skill
 
+Admins and curators create Skills through the same personal creation flow as other users.
+A new Skill belongs to its creator and starts private.
+Publishing means reviewing that Skill and then sharing it with the intended audience.
+
 <Steps>
-  <Step title="Upload the bundle">
-    Open **Craft → Skills** and select **Create skill**. Click the upload area to select `SKILL.md` or a ZIP,
-    or drag `SKILL.md`, a Skill folder, or a ZIP into it. Then select **Create**.
-    The new Skill starts private and is owned by the uploader.
+  <Step title="Create the personal Skill">
+    Open **Craft → Skills** and select **Create skill**. Choose **Start from scratch** to write the Skill in Onyx,
+    or choose **Upload a skill** to import `SKILL.md`, a ZIP, or a Skill folder.
+    Complete the editor and select **Create**.
   </Step>
 
-<Step title="Review the rendered instructions">
-  The editor shows the Skill's name, description, and `SKILL.md` instructions.
-  Switch between raw Markdown and preview to catch formatting or content issues.
-</Step>
+  <Step title="Review the Skill">
+    Review the name, description, rendered instructions, and supporting-file tree.
+    Confirm that Craft can understand when to use the Skill and that every included file is expected.
+  </Step>
 
-<Step title="Choose who can use it">
-  Select **Edit sharing** and grant Viewer access to specific users, groups, or
-  the organization. Use Editor access only for people responsible for
-  maintaining it.
-</Step>
+  <Step title="Choose who can use it">
+    Select **Edit sharing** and grant Viewer access to specific users, groups, or the organization.
+    Use Editor access only for people responsible for maintaining it.
+  </Step>
 
   <Step title="Test with the intended audience">
     Start a Craft session as a user in the target audience, select the Skill, and test representative inputs,
@@ -159,9 +158,8 @@ and delete it. Only the owner can transfer ownership;
 an Admin can transfer ownership after the existing owner becomes inactive or is otherwise vacant.
 
 <Tip>
-  Prefer organization-wide **Viewer** access with a small maintainer group as
-  **Editors**. This keeps the Skill broadly usable without making its behavior
-  broadly editable.
+  Prefer organization-wide **Viewer** access with a small maintainer group as **Editors**.
+  This keeps the Skill broadly usable without making its behavior broadly editable.
 </Tip>
 
 ## Maintain a Skill
@@ -171,7 +169,9 @@ Open a custom Skill to manage its lifecycle:
 | Action                 | Effect                                                                                                                             |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | **Edit details**       | Updates the name, description, or Markdown instructions and rewrites `SKILL.md` in the stored bundle.                              |
-| **Replace files**      | Replaces the complete bundle from `SKILL.md`, a ZIP, or a folder. The slug stays the same; metadata comes from the new `SKILL.md`. |
+| **Add files**          | Adds files, folders, or unpacked ZIP contents. A file at an existing path replaces the stored file.                              |
+| **Remove files**       | Removes a supporting file from the bundle. `SKILL.md` cannot be removed.                                                          |
+| **Replace content**    | Uploading content with `SKILL.md` replaces the name, description, instructions, and complete bundle after confirmation.           |
 | **Disable**            | Prevents Craft from using the Skill without deleting its configuration or sharing.                                                 |
 | **Edit sharing**       | Changes who can view or maintain the Skill.                                                                                        |
 | **Transfer ownership** | Assigns responsibility to another active standard user.                                                                            |
@@ -195,27 +195,24 @@ Do not transfer ownership to bots, service accounts, limited accounts, or inacti
     Confirm that the upload contains one Skill. `SKILL.md` must be at the top level of a folder. In a ZIP,
     place it at the archive root or directly inside one enclosing folder.
     Check that it uses UTF-8 and begins with valid YAML containing non-empty `name` and `description` fields.
-    For a standalone `SKILL.md`, make sure `name` is a valid Skill slug. Otherwise, check the folder or ZIP name.
-    Check the bundle limits, and remove symbolic links or unsafe paths.
+    For a standalone `SKILL.md`, make sure `name` contains at least one letter or number. Otherwise,
+    check the folder or ZIP name. Check the bundle limits, and remove symbolic links or unsafe paths.
   </Accordion>
 
 <Accordion title="A built-in Skill is unavailable">
-  Open its preview to read the unavailable reason. Configure Image Generation
-  for the image Skill, or ask the deployment operator to verify the browser
-  runtime for the Browser Skill. Built-in Skills cannot be replaced or enabled
-  from the Skills editor.
+  Open its preview to read the unavailable reason. Configure Image Generation for the image Skill,
+  or ask the deployment operator to verify the browser runtime for the Browser Skill.
+  Built-in Skills cannot be replaced or enabled from the Skills editor.
 </Accordion>
 
 <Accordion title="Users cannot find a shared Skill">
-  Confirm that the Skill is enabled and that the user or one of their groups has
-  Viewer or Editor access. If it was shared during an active session, start a
-  new turn or session and check the picker again.
+  Confirm that the Skill is enabled and that the user or one of their groups has Viewer or Editor access.
+  If it was shared during an active session, start a new turn or session and check the picker again.
 </Accordion>
 
 <Accordion title="Craft does not choose the Skill automatically">
-  Rewrite its description to name the covered tasks and outputs more concretely.
-  Test again, and have users select it explicitly when the workflow must be
-  followed.
+  Rewrite its description to name the covered tasks and outputs more concretely. Test again,
+  and have users select it explicitly when the workflow must be followed.
 </Accordion>
 
   <Accordion title="A former employee still owns a Skill">

--- a/admins/managing_features/craft_skills.mdx
+++ b/admins/managing_features/craft_skills.mdx
@@ -8,8 +8,8 @@ Skills package reusable instructions and supporting files that teach Craft how t
 Open **Craft → Skills** to review, upload, share, and manage Skills.
 
 <Note>
-  Curators can also upload Skills and manage Skills they own or can edit.
-  Admins can inspect and manage all custom Skills, including private personal Skills.
+  Curators can also upload Skills and manage Skills they own or can edit. Admins
+  can inspect and manage all custom Skills, including private personal Skills.
 </Note>
 
 ## Understand the Skills library
@@ -35,17 +35,21 @@ Configure the missing dependency rather than uploading a custom Skill with the s
 
 ## Prepare a custom Skill
 
-A custom Skill is a ZIP archive with `SKILL.md` at its root. The ZIP filename becomes the permanent slug,
-so choose a stable lowercase, hyphenated filename.
+Upload `SKILL.md` directly when the Skill does not need supporting files.
+For a Skill with scripts, examples, or other supporting files, create a folder with `SKILL.md` at its top level.
+Drag the folder into Onyx, or upload it as a ZIP.
 
 <Info>
-  Onyx removes `.zip` from the filename and uses the remaining text as the Skill slug. Skill slugs must be unique.
-  If an existing Skill already uses that slug, the upload fails. Rename the ZIP to create a separate Skill,
-  or replace the files on the existing Skill.
+  For a standalone `SKILL.md`, the frontmatter `name` becomes the Skill slug.
+  For a folder, the folder name becomes the slug. For a ZIP, the filename
+  without `.zip` becomes the slug. Slugs must start with a lowercase letter,
+  contain only lowercase letters, numbers, and hyphens, and be no more than 64
+  characters. They must also be unique. If an existing Skill already uses the
+  slug, replace that Skill's files or change the slug source before uploading.
 </Info>
 
 ```text
-weekly-customer-update.zip
+weekly-customer-update/
 ├── SKILL.md
 ├── examples/
 │   └── finished-update.md
@@ -55,12 +59,16 @@ weekly-customer-update.zip
     └── validate.py
 ```
 
+For a ZIP upload, put `SKILL.md` at the archive root or directly inside one enclosing folder.
+When you use an enclosing folder, keep every Skill file inside it.
+Upload only one Skill at a time.
+
 `SKILL.md` must begin with YAML frontmatter containing a non-empty name and description.
 The description should state when Craft should choose the Skill.
 
 ```md
 ---
-name: Weekly customer update
+name: weekly-customer-update
 description: Create a weekly customer update from account activity and meeting notes.
 ---
 
@@ -75,18 +83,19 @@ description: Create a weekly customer update from account activity and meeting n
 
 ### Bundle requirements
 
-| Requirement         | Default                                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Slug                | ZIP filename without `.zip`; lowercase letters, numbers, and hyphens; starts with a letter; maximum 64 characters. |
-| Root instructions   | One UTF-8 `SKILL.md` file with valid YAML frontmatter.                                                             |
-| Maximum file size   | 25 MB per file in the extracted bundle.                                                                            |
-| Maximum bundle size | 100 MB total.                                                                                                      |
+| Requirement         | Default                                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Slug                | Standalone frontmatter `name`, folder name, or ZIP filename without `.zip`; lowercase letters, numbers, and hyphens; maximum 64 characters. |
+| Root instructions   | One UTF-8 `SKILL.md` with valid YAML frontmatter at the Skill root.                                                                         |
+| Skills per upload   | One.                                                                                                                                        |
+| Maximum file size   | 25 MB per file in the extracted bundle.                                                                                                     |
+| Maximum bundle size | 100 MB total.                                                                                                                               |
 
 Self-hosted operators can change the size limits with `SKILL_BUNDLE_PER_FILE_MAX_BYTES` and
 `SKILL_BUNDLE_TOTAL_MAX_BYTES`.
 
-The upload is rejected when the archive has unsafe paths, symbolic links, files ending in `.template`,
-missing or invalid frontmatter, an invalid filename, a duplicate Skill slug,
+The upload is rejected when the bundle has unsafe paths, symbolic links, files ending in `.template`,
+missing or invalid frontmatter, an invalid slug source, a duplicate Skill slug,
 or a slug reserved by a built-in Skill or App.
 
 ## Review a Skill before publishing
@@ -104,28 +113,32 @@ Craft can follow scripts and commands included in the archive.
 | **Output handling**        | The Skill names the expected format and writes finished deliverables to a clear location such as `outputs/`.       |
 
 <Warning>
-  Never publish a bundle containing passwords, API keys, OAuth tokens, private certificates, or production credentials.
-  Skill files are copied into the sandboxes of users who can access the Skill.
-  Use [Apps](/admins/managing_features/craft_apps) for authenticated external access.
+  Never publish a bundle containing passwords, API keys, OAuth tokens, private
+  certificates, or production credentials. Skill files are copied into the
+  sandboxes of users who can access the Skill. Use
+  [Apps](/admins/managing_features/craft_apps) for authenticated external
+  access.
 </Warning>
 
 ## Publish a Skill
 
 <Steps>
   <Step title="Upload the bundle">
-    Open **Craft → Skills**, select **Create skill**, choose the ZIP archive, and upload it.
+    Open **Craft → Skills** and select **Create skill**. Click the upload area to select `SKILL.md` or a ZIP,
+    or drag `SKILL.md`, a Skill folder, or a ZIP into it. Then select **Create**.
     The new Skill starts private and is owned by the uploader.
   </Step>
 
-  <Step title="Review the rendered instructions">
-    The editor shows the Skill's name, description, and `SKILL.md` instructions.
-    Switch between raw Markdown and preview to catch formatting or content issues.
-  </Step>
+<Step title="Review the rendered instructions">
+  The editor shows the Skill's name, description, and `SKILL.md` instructions.
+  Switch between raw Markdown and preview to catch formatting or content issues.
+</Step>
 
-  <Step title="Choose who can use it">
-    Select **Edit sharing** and grant Viewer access to specific users, groups, or the organization.
-    Use Editor access only for people responsible for maintaining it.
-  </Step>
+<Step title="Choose who can use it">
+  Select **Edit sharing** and grant Viewer access to specific users, groups, or
+  the organization. Use Editor access only for people responsible for
+  maintaining it.
+</Step>
 
   <Step title="Test with the intended audience">
     Start a Craft session as a user in the target audience, select the Skill, and test representative inputs,
@@ -146,22 +159,23 @@ and delete it. Only the owner can transfer ownership;
 an Admin can transfer ownership after the existing owner becomes inactive or is otherwise vacant.
 
 <Tip>
-  Prefer organization-wide **Viewer** access with a small maintainer group as **Editors**.
-  This keeps the Skill broadly usable without making its behavior broadly editable.
+  Prefer organization-wide **Viewer** access with a small maintainer group as
+  **Editors**. This keeps the Skill broadly usable without making its behavior
+  broadly editable.
 </Tip>
 
 ## Maintain a Skill
 
 Open a custom Skill to manage its lifecycle:
 
-| Action                 | Effect                                                                                                          |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Edit details**       | Updates the name, description, or Markdown instructions and rewrites `SKILL.md` in the stored bundle.           |
-| **Replace files**      | Replaces the complete ZIP. The slug stays the same; metadata and instructions are read from the new `SKILL.md`. |
-| **Disable**            | Prevents Craft from using the Skill without deleting its configuration or sharing.                              |
-| **Edit sharing**       | Changes who can view or maintain the Skill.                                                                     |
-| **Transfer ownership** | Assigns responsibility to another active standard user.                                                         |
-| **Delete**             | Permanently removes the Skill and its stored bundle.                                                            |
+| Action                 | Effect                                                                                                                             |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Edit details**       | Updates the name, description, or Markdown instructions and rewrites `SKILL.md` in the stored bundle.                              |
+| **Replace files**      | Replaces the complete bundle from `SKILL.md`, a ZIP, or a folder. The slug stays the same; metadata comes from the new `SKILL.md`. |
+| **Disable**            | Prevents Craft from using the Skill without deleting its configuration or sharing.                                                 |
+| **Edit sharing**       | Changes who can view or maintain the Skill.                                                                                        |
+| **Transfer ownership** | Assigns responsibility to another active standard user.                                                                            |
+| **Delete**             | Permanently removes the Skill and its stored bundle.                                                                               |
 
 Changes are synchronized to affected running sandboxes.
 A turn already in progress may have loaded the previous instructions,
@@ -177,27 +191,32 @@ Do not transfer ownership to bots, service accounts, limited accounts, or inacti
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="A ZIP will not upload">
-    Confirm that `SKILL.md` is at the archive root, uses UTF-8,
-    and begins with valid YAML containing non-empty `name` and `description` fields.
-    Check the filename and bundle limits, and remove symbolic links or unsafe archive paths.
+  <Accordion title="A Skill bundle will not upload">
+    Confirm that the upload contains one Skill. `SKILL.md` must be at the top level of a folder. In a ZIP,
+    place it at the archive root or directly inside one enclosing folder.
+    Check that it uses UTF-8 and begins with valid YAML containing non-empty `name` and `description` fields.
+    For a standalone `SKILL.md`, make sure `name` is a valid Skill slug. Otherwise, check the folder or ZIP name.
+    Check the bundle limits, and remove symbolic links or unsafe paths.
   </Accordion>
 
-  <Accordion title="A built-in Skill is unavailable">
-    Open its preview to read the unavailable reason. Configure Image Generation for the image Skill,
-    or ask the deployment operator to verify the browser runtime for the Browser Skill.
-    Built-in Skills cannot be replaced or enabled from the Skills editor.
-  </Accordion>
+<Accordion title="A built-in Skill is unavailable">
+  Open its preview to read the unavailable reason. Configure Image Generation
+  for the image Skill, or ask the deployment operator to verify the browser
+  runtime for the Browser Skill. Built-in Skills cannot be replaced or enabled
+  from the Skills editor.
+</Accordion>
 
-  <Accordion title="Users cannot find a shared Skill">
-    Confirm that the Skill is enabled and that the user or one of their groups has Viewer or Editor access.
-    If it was shared during an active session, start a new turn or session and check the picker again.
-  </Accordion>
+<Accordion title="Users cannot find a shared Skill">
+  Confirm that the Skill is enabled and that the user or one of their groups has
+  Viewer or Editor access. If it was shared during an active session, start a
+  new turn or session and check the picker again.
+</Accordion>
 
-  <Accordion title="Craft does not choose the Skill automatically">
-    Rewrite its description to name the covered tasks and outputs more concretely. Test again,
-    and have users select it explicitly when the workflow must be followed.
-  </Accordion>
+<Accordion title="Craft does not choose the Skill automatically">
+  Rewrite its description to name the covered tasks and outputs more concretely.
+  Test again, and have users select it explicitly when the workflow must be
+  followed.
+</Accordion>
 
   <Accordion title="A former employee still owns a Skill">
     After the account is inactive, an Admin can open the Skill, select **Edit sharing**,

--- a/overview/core_features/craft_skills.mdx
+++ b/overview/core_features/craft_skills.mdx
@@ -11,16 +11,11 @@ For example, a slide skill can tell Craft how to choose layouts, apply a templat
 and save the presentation in the right format. You provide the goal and source material; the skill provides the method.
 
 <Note>
-  Skills do not connect external accounts or hold credentials. To let Craft read
-  from or act in tools like Slack, Gmail, or GitHub, connect an
-  [App](/overview/core_features/craft_apps).
+  Skills do not connect external accounts or hold credentials. To let Craft read from or act in tools like Slack, Gmail,
+  or GitHub, connect an [App](/overview/core_features/craft_apps).
 </Note>
 
-<img
-  className="rounded-image"
-  src="/assets/overview/core_features/craft_skills.png"
-  alt="The Craft Skills page showing built-in skills and controls for browsing and creating skills"
-/>
+<img className="rounded-image" src="/assets/overview/core_features/craft_skills.png" alt="The Skills page in Craft"/>
 
 ## How Craft uses skills
 
@@ -33,10 +28,10 @@ You can also select one explicitly when you want Craft to follow a particular wo
     You can also type **/** followed by the skill name. The selected skill appears as a chip above the input.
   </Step>
 
-<Step title="Describe the result">
-  Tell Craft what to produce and provide the audience, source material, and
-  requirements that matter. Selecting a skill does not replace a clear prompt.
-</Step>
+  <Step title="Describe the result">
+    Tell Craft what to produce and provide the audience, source material, and requirements that matter.
+    Selecting a skill does not replace a clear prompt.
+  </Step>
 
   <Step title="Review and refine">
     Craft reads the skill instructions before doing covered work. Review the result,
@@ -68,17 +63,57 @@ Built-in skills currently cover presentations, company search, image generation,
 The exact list you see depends on what your organization has enabled.
 
 <Tip>
-  A skill's description tells Craft when to use it. If Craft repeatedly misses a
-  custom skill, make the description concrete about the tasks it covers, or
-  select the skill explicitly in your prompt.
+  A skill's description tells Craft when to use it. If Craft repeatedly misses a custom skill,
+  make the description concrete about the tasks it covers, or select the skill explicitly in your prompt.
 </Tip>
 
 ## Create a personal skill
 
-Create a personal skill when you have instructions or reference files you want to reuse across sessions.
-Upload `SKILL.md` directly when the Skill contains instructions only.
-When the Skill needs supporting files, create it as a folder with `SKILL.md` at the top level.
-You can drag the folder into Onyx or upload it as a ZIP.
+Create a personal Skill when you have instructions, examples, or reference files you want to reuse across sessions.
+Open **Skills**, select **Create skill**, then choose how you want to begin:
+
+| Starting point | Choose | What happens |
+| --- | --- | --- |
+| You want to write the Skill in Onyx | **Start from scratch** | The Skill editor opens so you can write the details and instructions, then add supporting files. |
+| You already have a Skill | **Upload a skill** | Upload `SKILL.md`, a ZIP, or a Skill folder. Onyx reads the instructions and creates the Skill for you. |
+
+Every new Skill is personal and private. After creating it, you can share it from the Skill editor.
+
+### Start from scratch
+
+<Steps>
+  <Step title="Add the details">
+    Enter a name and describe when Craft should use the Skill. Onyx uses the name to create the Skill's identifier,
+    converting spaces and punctuation to hyphens when needed.
+  </Step>
+
+  <Step title="Write the instructions">
+    Describe the workflow Craft should follow, including important constraints, expected outputs, and checks.
+    Switch between the Markdown editor and preview to review the finished instructions.
+  </Step>
+
+  <Step title="Add supporting files">
+    Add references, examples, templates, scripts, or assets under **Supporting files**. You can select files or a ZIP,
+    or drag in a folder. Onyx unpacks ZIP files and preserves the directory structure.
+  </Step>
+
+  <Step title="Create the Skill">
+    Select **Create**. Onyx saves the instructions as `SKILL.md` and opens the Skill editor, where you can manage files,
+    sharing, and availability.
+  </Step>
+</Steps>
+
+<Info>
+  If you already have a Skill,
+  use **Import skill** at the top of the creation page to fill in the form and add its files.
+  If you have already entered content, Onyx asks before replacing the name, description, instructions,
+  and supporting files with the imported Skill.
+</Info>
+
+### Upload an existing Skill
+
+Upload `SKILL.md` directly when the Skill contains instructions only. When it includes supporting files,
+upload a ZIP or drag in a folder with `SKILL.md` at the top level.
 
 ```text
 weekly-customer-update/
@@ -93,7 +128,7 @@ At minimum, `SKILL.md` needs a name and description in YAML frontmatter, followe
 
 ```md
 ---
-name: weekly-customer-update
+name: Weekly customer update
 description: Create a concise weekly customer update from meeting notes and account activity.
 ---
 
@@ -107,35 +142,40 @@ description: Create a concise weekly customer update from meeting notes and acco
 
 <Steps>
   <Step title="Prepare the bundle">
-    Put the Skill's instructions in `SKILL.md`, with any supporting files in the same folder.
-    Use a lowercase, hyphenated slug such as `weekly-customer-update`.
-    For a standalone `SKILL.md`, its frontmatter `name` becomes the slug.
-    For a folder or ZIP, the folder name or ZIP filename becomes the slug.
+    Put the instructions in `SKILL.md` and keep supporting files in the same folder. For a folder or ZIP,
+    use a lowercase, hyphenated name such as `weekly-customer-update`; that name becomes the Skill's identifier.
+    For a standalone `SKILL.md`, Onyx creates the identifier from its frontmatter `name`.
   </Step>
 
-<Step title="Upload it">
-  Open **Skills** and select **Create skill**. Click the upload area to select
-  `SKILL.md` or a ZIP, or drag `SKILL.md`, a Skill folder, or a ZIP into it.
-  Upload one Skill at a time. Select **Create**. Your new Skill is private by
-  default.
-</Step>
+  <Step title="Upload the Skill">
+    Open **Skills**, select **Create skill** > **Upload a skill**, and select `SKILL.md` or a ZIP.
+    You can also drag `SKILL.md`, a ZIP, or a Skill folder into the upload area. Upload one Skill at a time,
+    then select **Create**.
+  </Step>
 
-<Step title="Review the instructions">
-  Open the skill to edit its name, description, or instructions. You can switch
-  between the raw Markdown and rendered preview.
-</Step>
-
-  <Step title="Manage its lifecycle">
-    From the skill editor, you can replace the bundle, disable the skill without deleting it,
-    share it with people or groups, transfer ownership, or delete it.
+  <Step title="Review the Skill">
+    Onyx opens the Skill editor after creating it. Review the name, description, instructions,
+    and file tree before using or sharing the Skill.
   </Step>
 </Steps>
 
+### Update a Skill
+
+Open a personal Skill to edit its name, description, or instructions. Under **Supporting files**, you can:
+
+- Add individual files, ZIP files, or folders. New files are added to the existing bundle, and matching paths are
+  replaced.
+- Browse the bundle as a directory tree and remove files you no longer need. `SKILL.md` cannot be removed.
+- Upload content that includes `SKILL.md` to replace the current name, description, instructions, and files. Onyx asks
+  you to confirm before replacing the existing Skill content.
+
+Changes are synchronized to people who can use the Skill. You can also disable the Skill without deleting it,
+change its sharing, transfer ownership, or delete it.
+
 <Warning>
-  Never put passwords, API keys, tokens, or production credentials in a skill
-  bundle. Use [Apps](/overview/core_features/craft_apps) for authenticated
-  access to external services. Review every script and file before uploading a
-  bundle you did not create.
+  Never put passwords, API keys, tokens, or production credentials in a skill bundle.
+  Use [Apps](/overview/core_features/craft_apps) for authenticated access to external services.
+  Review every script and file before uploading a bundle you did not create.
 </Warning>
 
 ## Troubleshooting
@@ -147,17 +187,16 @@ description: Create a concise weekly customer update from meeting notes and acco
   </Accordion>
 
 <Accordion title="Craft did not use the skill I expected">
-  Select the skill from **+** > **Skills** or type **/** and choose it before
-  sending your prompt. Also name the desired output and important constraints; a
-  skill supplies a method, not the goal itself.
+  Select the skill from **+** > **Skills** or type **/** and choose it before sending your prompt.
+  Also name the desired output and important constraints; a skill supplies a method, not the goal itself.
 </Accordion>
 
   <Accordion title="My Skill will not upload">
-    Upload one Skill at a time. Put `SKILL.md` at the top level of the folder.
-    In a ZIP, place it at the archive root or directly inside one enclosing folder.
-    Confirm that its frontmatter contains non-empty `name` and `description` fields.
-    For a standalone `SKILL.md`, `name` must be lowercase and hyphenated. For a folder or ZIP, check that its name is
-    lowercase and hyphenated. The Skill slug cannot use a reserved built-in name.
+    Upload one Skill at a time. Put `SKILL.md` at the top level of the folder. In a ZIP,
+    place it at the archive root or directly inside one enclosing folder.
+    Confirm that its frontmatter contains non-empty `name` and `description` fields. For a folder or ZIP,
+    check that its name is lowercase and hyphenated. If you started from scratch, try a different Skill name.
+    A custom Skill cannot use the same identifier as an existing or built-in Skill.
   </Accordion>
 </AccordionGroup>
 

--- a/overview/core_features/craft_skills.mdx
+++ b/overview/core_features/craft_skills.mdx
@@ -11,11 +11,16 @@ For example, a slide skill can tell Craft how to choose layouts, apply a templat
 and save the presentation in the right format. You provide the goal and source material; the skill provides the method.
 
 <Note>
-  Skills do not connect external accounts or hold credentials. To let Craft read from or act in tools like Slack, Gmail,
-  or GitHub, connect an [App](/overview/core_features/craft_apps).
+  Skills do not connect external accounts or hold credentials. To let Craft read
+  from or act in tools like Slack, Gmail, or GitHub, connect an
+  [App](/overview/core_features/craft_apps).
 </Note>
 
-<img className="rounded-image" src="/assets/overview/core_features/craft_skills.png" alt="The Craft Skills page showing built-in skills and controls for browsing and creating skills"/>
+<img
+  className="rounded-image"
+  src="/assets/overview/core_features/craft_skills.png"
+  alt="The Craft Skills page showing built-in skills and controls for browsing and creating skills"
+/>
 
 ## How Craft uses skills
 
@@ -28,10 +33,10 @@ You can also select one explicitly when you want Craft to follow a particular wo
     You can also type **/** followed by the skill name. The selected skill appears as a chip above the input.
   </Step>
 
-  <Step title="Describe the result">
-    Tell Craft what to produce and provide the audience, source material, and requirements that matter.
-    Selecting a skill does not replace a clear prompt.
-  </Step>
+<Step title="Describe the result">
+  Tell Craft what to produce and provide the audience, source material, and
+  requirements that matter. Selecting a skill does not replace a clear prompt.
+</Step>
 
   <Step title="Review and refine">
     Craft reads the skill instructions before doing covered work. Review the result,
@@ -63,17 +68,20 @@ Built-in skills currently cover presentations, company search, image generation,
 The exact list you see depends on what your organization has enabled.
 
 <Tip>
-  A skill's description tells Craft when to use it. If Craft repeatedly misses a custom skill,
-  make the description concrete about the tasks it covers, or select the skill explicitly in your prompt.
+  A skill's description tells Craft when to use it. If Craft repeatedly misses a
+  custom skill, make the description concrete about the tasks it covers, or
+  select the skill explicitly in your prompt.
 </Tip>
 
 ## Create a personal skill
 
 Create a personal skill when you have instructions or reference files you want to reuse across sessions.
-A skill is a ZIP bundle with a `SKILL.md` file at its root.
+Upload `SKILL.md` directly when the Skill contains instructions only.
+When the Skill needs supporting files, create it as a folder with `SKILL.md` at the top level.
+You can drag the folder into Onyx or upload it as a ZIP.
 
 ```text
-weekly-customer-update.zip
+weekly-customer-update/
 ├── SKILL.md
 ├── examples/
 │   └── finished-update.md
@@ -85,7 +93,7 @@ At minimum, `SKILL.md` needs a name and description in YAML frontmatter, followe
 
 ```md
 ---
-name: Weekly customer update
+name: weekly-customer-update
 description: Create a concise weekly customer update from meeting notes and account activity.
 ---
 
@@ -99,19 +107,23 @@ description: Create a concise weekly customer update from meeting notes and acco
 
 <Steps>
   <Step title="Prepare the bundle">
-    Use a lowercase, hyphenated ZIP filename such as `weekly-customer-update.zip`.
-    Put `SKILL.md` at the root of the ZIP and add any examples, templates, or helper files it needs.
+    Put the Skill's instructions in `SKILL.md`, with any supporting files in the same folder.
+    Use a lowercase, hyphenated slug such as `weekly-customer-update`.
+    For a standalone `SKILL.md`, its frontmatter `name` becomes the slug.
+    For a folder or ZIP, the folder name or ZIP filename becomes the slug.
   </Step>
 
-  <Step title="Upload it">
-    Open **Skills**, select **Create skill**, choose the ZIP, and select **Create**.
-    Your new skill is private by default.
-  </Step>
+<Step title="Upload it">
+  Open **Skills** and select **Create skill**. Click the upload area to select
+  `SKILL.md` or a ZIP, or drag `SKILL.md`, a Skill folder, or a ZIP into it.
+  Upload one Skill at a time. Select **Create**. Your new Skill is private by
+  default.
+</Step>
 
-  <Step title="Review the instructions">
-    Open the skill to edit its name, description, or instructions.
-    You can switch between the raw Markdown and rendered preview.
-  </Step>
+<Step title="Review the instructions">
+  Open the skill to edit its name, description, or instructions. You can switch
+  between the raw Markdown and rendered preview.
+</Step>
 
   <Step title="Manage its lifecycle">
     From the skill editor, you can replace the bundle, disable the skill without deleting it,
@@ -120,9 +132,10 @@ description: Create a concise weekly customer update from meeting notes and acco
 </Steps>
 
 <Warning>
-  Never put passwords, API keys, tokens, or production credentials in a skill bundle.
-  Use [Apps](/overview/core_features/craft_apps) for authenticated access to external services.
-  Review every script and file before uploading a bundle you did not create.
+  Never put passwords, API keys, tokens, or production credentials in a skill
+  bundle. Use [Apps](/overview/core_features/craft_apps) for authenticated
+  access to external services. Review every script and file before uploading a
+  bundle you did not create.
 </Warning>
 
 ## Troubleshooting
@@ -134,14 +147,17 @@ description: Create a concise weekly customer update from meeting notes and acco
   </Accordion>
 
 <Accordion title="Craft did not use the skill I expected">
-  Select the skill from **+** > **Skills** or type **/** and choose it before sending your prompt.
-  Also name the desired output and important constraints; a skill supplies a method, not the goal itself.
+  Select the skill from **+** > **Skills** or type **/** and choose it before
+  sending your prompt. Also name the desired output and important constraints; a
+  skill supplies a method, not the goal itself.
 </Accordion>
 
-  <Accordion title="My ZIP will not upload">
-    Check that the filename is lowercase and hyphenated, `SKILL.md` is at the root of the ZIP,
-    its frontmatter contains non-empty `name` and `description` fields,
-    and the bundle does not use a reserved built-in name.
+  <Accordion title="My Skill will not upload">
+    Upload one Skill at a time. Put `SKILL.md` at the top level of the folder.
+    In a ZIP, place it at the archive root or directly inside one enclosing folder.
+    Confirm that its frontmatter contains non-empty `name` and `description` fields.
+    For a standalone `SKILL.md`, `name` must be lowercase and hyphenated. For a folder or ZIP, check that its name is
+    lowercase and hyphenated. The Skill slug cannot use a reserved built-in name.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

- document both Skill creation paths: starting in the editor or uploading an existing Skill
- explain importing `SKILL.md`, ZIP files, folders, and supporting files
- cover replacement warnings, directory browsing, file removal, and identifier generation
- clarify that admins and curators publish a personal Skill by updating its sharing

Related code change: onyx-dot-app/onyx#13014