### PR TITLE
docs: update auth pages for admin-panel SSO, per-provider settings, and the password kill switch

### DIFF
--- a/deployment/authentication/basic.mdx
+++ b/deployment/authentication/basic.mdx
@@ -1,11 +1,21 @@
 ---
 title: "Basic Auth"
-description: "Set up Onyx with basic username/password authentication"
+description: "Email and password authentication in Onyx"
 icon: "user-lock"
 ---
 
-Basic Auth is the easiest way to get started with Onyx. However, we recommend using Google OAuth, OIDC,
-or SAML for production deployments.
+Email/password authentication is always enabled and works out of the box, with no configuration needed.
+The first user to sign up becomes an admin.
+
+We recommend adding [Google OAuth](/deployment/authentication/oauth), [OIDC](/deployment/authentication/oidc),
+or [SAML](/deployment/authentication/saml) for production deployments. Once SSO works,
+password login and sign-up can be [turned off
+entirely](/deployment/authentication/sso_providers#turning-off-password-login).
+
+<Note>
+  Versions before `v4.4.0` required `AUTH_TYPE=basic`.
+  Since `v4.4.0` the variable is inert and it is planned for full removal in `v4.5`.
+</Note>
 
 <Tip>
   If you have questions about which authentication approach is best for your organization,
@@ -13,39 +23,12 @@ or SAML for production deployments.
   - we're happy to help you choose the right solution.
 </Tip>
 
-## Basic Setup
+## Password Requirements
 
-**Using Docker:**
+Passwords must be 8 to 64 characters by default. The length limits and character-class requirements (uppercase,
+lowercase, number, special character) are configurable at **Admin Panel** → **Organization** → **Security & Hardening**.
 
-In your `.env` file, set:
-
-```bash
-AUTH_TYPE=basic
-```
-
-**Using Helm:**
-
-In your `values.yaml` file, set:
-
-```yaml
-configMap:
-  AUTH_TYPE: basic
-```
-
-If you don't need email verification, you're done!
-
-Restart Onyx to apply the changes and the next time you visit the site,
-you'll be prompted to create an account and set a password.
-
-<Accordion title="Password Requirements">
-  - 12+ characters
-  - 1 number
-  - 1 special character
-  - 1 uppercase letter
-  - 1 lowercase letter
-</Accordion>
-
-## Basic Auth with Email Verification
+## Email Verification
 
 Enabling email verification blocks your users from signing in until they click their verification email.
 
@@ -54,8 +37,6 @@ Enabling email verification blocks your users from signing in until they click t
 Set the following in your `.env` file:
 
 ```bash
-AUTH_TYPE=basic
-
 # Enable email verification
 REQUIRE_EMAIL_VERIFICATION=true
 
@@ -77,8 +58,6 @@ auth:
   secrets:
       smpt_pass: <PASSWORD_FOR_THE_SMTP_USER>
 configMap:
-  AUTH_TYPE: basic
-
   REQUIRE_EMAIL_VERIFICATION: true
   SMTP_USER: <EMAIL_TO_SEND_VERIFICATION_EMAILS_FROM>
 

--- a/deployment/authentication/oauth.mdx
+++ b/deployment/authentication/oauth.mdx
@@ -113,13 +113,12 @@ see [Plan Availability](/deployment/authentication/sso_providers#plan-availabili
 
 By default, Onyx requests `openid`, `email`,
 and `profile` from Google during login — the minimum needed to identify the user.
-Overriding the list is primarily useful when the access token issued at login should be passed through
-to tool calls that need additional Google API access.
+Overriding the list is primarily useful when the access token issued at login should be passed through to tool calls
+that need additional Google API access.
 
-Starting in `v4.5`, set **Scopes** on the provider entry
-(**Admin Panel** → **Organization** → **SSO Providers**) to override the list per provider.
-A provider's **Scopes** take precedence. When left empty, the deployment-wide
-environment variable applies, then the built-in defaults.
+Starting in `v4.5`, set **Scopes** on the provider entry (**Admin Panel** → **Organization** → **SSO Providers**)
+to override the list per provider. A provider's **Scopes** take precedence. When left empty,
+the deployment-wide environment variable applies, then the built-in defaults.
 
 On `v4.4.x`, the only override is the deployment-wide `GOOGLE_OAUTH_SCOPE_OVERRIDE` environment variable,
 a comma-separated list:
@@ -148,20 +147,19 @@ GOOGLE_OAUTH_SCOPE_OVERRIDE=openid,email,profile,https://www.googleapis.com/auth
 
 PKCE is disabled by default.
 
-Starting in `v4.5`, turn on **Enable PKCE** on the provider entry
-(**Admin Panel** → **Organization** → **SSO Providers**).
+Starting in `v4.5`,
+turn on **Enable PKCE** on the provider entry (**Admin Panel** → **Organization** → **SSO Providers**).
 
-On `v4.4.x`, the deployment-wide `OIDC_PKCE_ENABLED` environment variable enables it for all
-providers. Google login shares the OIDC login route, so the OIDC-named variable applies here too:
+On `v4.4.x`, the deployment-wide `OIDC_PKCE_ENABLED` environment variable enables it for all providers.
+Google login shares the OIDC login route, so the OIDC-named variable applies here too:
 
 ```bash .env
 OIDC_PKCE_ENABLED=true
 ```
 
 <Warning>
-  `OIDC_PKCE_ENABLED=true` forces PKCE on for every provider, including
-  providers whose **Enable PKCE** toggle is off. Unset it if you want the
-  per-provider toggles to be the source of truth.
+  `OIDC_PKCE_ENABLED=true` forces PKCE on for every provider, including providers whose **Enable PKCE** toggle is off.
+  Unset it if you want the per-provider toggles to be the source of truth.
 </Warning>
 
 ## Upgrading from v4.3 or Earlier
@@ -178,8 +176,8 @@ New installs must use the admin panel flow above.
   so keep the configuration in place through the upgrade.
   The migrated provider keeps using the redirect URI already registered in the Google Cloud Console,
   so nothing changes on the Google side. Once the migrated provider appears in the admin panel,
-  sign-ins and token refresh use the provider entry's credentials, and `AUTH_TYPE`,
-  `OAUTH_CLIENT_ID`, and `OAUTH_CLIENT_SECRET` can be removed.
+  sign-ins and token refresh use the provider entry's credentials, and `AUTH_TYPE`, `OAUTH_CLIENT_ID`,
+  and `OAUTH_CLIENT_SECRET` can be removed.
   The variables only act as a fallback for login accounts that no provider entry matches,
   such as after deleting or renaming the migrated provider.
 </Note>

--- a/deployment/authentication/oauth.mdx
+++ b/deployment/authentication/oauth.mdx
@@ -113,15 +113,16 @@ see [Plan Availability](/deployment/authentication/sso_providers#plan-availabili
 
 By default, Onyx requests `openid`, `email`,
 and `profile` from Google during login — the minimum needed to identify the user.
-This is primarily useful when the access token issued at login should be passed through to tool calls that need
-additional Google API access.
+Overriding the list is primarily useful when the access token issued at login should be passed through
+to tool calls that need additional Google API access.
 
 Starting in `v4.5`, set **Scopes** on the provider entry
 (**Admin Panel** → **Organization** → **SSO Providers**) to override the list per provider.
-The provider entry also offers an **Enable PKCE** toggle from `v4.5`.
+A provider's **Scopes** take precedence. When left empty, the deployment-wide
+environment variable applies, then the built-in defaults.
 
-On `v4.4.x`, the override is the deployment-wide `GOOGLE_OAUTH_SCOPE_OVERRIDE` environment variable,
-a comma-separated list. It is planned for removal in `v4.5` in favor of the per-provider setting.
+On `v4.4.x`, the only override is the deployment-wide `GOOGLE_OAUTH_SCOPE_OVERRIDE` environment variable,
+a comma-separated list:
 
 ```bash .env
 GOOGLE_OAUTH_SCOPE_OVERRIDE=openid,email,profile,https://www.googleapis.com/auth/drive.readonly
@@ -143,6 +144,26 @@ GOOGLE_OAUTH_SCOPE_OVERRIDE=openid,email,profile,https://www.googleapis.com/auth
   The Google Drive and Gmail **connectors** use their own scopes and OAuth flow, which are not affected by this setting.
 </Note>
 
+## Enabling PKCE
+
+PKCE is disabled by default.
+
+Starting in `v4.5`, turn on **Enable PKCE** on the provider entry
+(**Admin Panel** → **Organization** → **SSO Providers**).
+
+On `v4.4.x`, the deployment-wide `OIDC_PKCE_ENABLED` environment variable enables it for all
+providers. Google login shares the OIDC login route, so the OIDC-named variable applies here too:
+
+```bash .env
+OIDC_PKCE_ENABLED=true
+```
+
+<Warning>
+  `OIDC_PKCE_ENABLED=true` forces PKCE on for every provider, including
+  providers whose **Enable PKCE** toggle is off. Unset it if you want the
+  per-provider toggles to be the source of truth.
+</Warning>
+
 ## Upgrading from v4.3 or Earlier
 
 Versions before `v4.4.0` configured a single Google provider through environment variables,
@@ -156,10 +177,11 @@ New installs must use the admin panel flow above.
   and existing logins keep working. The import runs once, when the upgrade first runs against your existing database,
   so keep the configuration in place through the upgrade.
   The migrated provider keeps using the redirect URI already registered in the Google Cloud Console,
-  so nothing changes on the Google side.
-  Keep `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` in place after the upgrade too:
-  the token-refresh path for signed-in users still reads them until their planned removal in `v4.5`.
-  `AUTH_TYPE` itself can be removed once the provider appears in the admin panel.
+  so nothing changes on the Google side. Once the migrated provider appears in the admin panel,
+  sign-ins and token refresh use the provider entry's credentials, and `AUTH_TYPE`,
+  `OAUTH_CLIENT_ID`, and `OAUTH_CLIENT_SECRET` can be removed.
+  The variables only act as a fallback for login accounts that no provider entry matches,
+  such as after deleting or renaming the migrated provider.
 </Note>
 
 For reference, a pre-`v4.4.0` configuration looks like:

--- a/deployment/authentication/oauth.mdx
+++ b/deployment/authentication/oauth.mdx
@@ -113,9 +113,15 @@ see [Plan Availability](/deployment/authentication/sso_providers#plan-availabili
 
 By default, Onyx requests `openid`, `email`,
 and `profile` from Google during login — the minimum needed to identify the user.
-You can override this list with `GOOGLE_OAUTH_SCOPE_OVERRIDE`, a comma-separated list of scopes to request instead.
 This is primarily useful when the access token issued at login should be passed through to tool calls that need
 additional Google API access.
+
+Starting in `v4.5`, set **Scopes** on the provider entry
+(**Admin Panel** → **Organization** → **SSO Providers**) to override the list per provider.
+The provider entry also offers an **Enable PKCE** toggle from `v4.5`.
+
+On `v4.4.x`, the override is the deployment-wide `GOOGLE_OAUTH_SCOPE_OVERRIDE` environment variable,
+a comma-separated list. It is planned for removal in `v4.5` in favor of the per-provider setting.
 
 ```bash .env
 GOOGLE_OAUTH_SCOPE_OVERRIDE=openid,email,profile,https://www.googleapis.com/auth/drive.readonly

--- a/deployment/authentication/oauth.mdx
+++ b/deployment/authentication/oauth.mdx
@@ -150,7 +150,10 @@ New installs must use the admin panel flow above.
   and existing logins keep working. The import runs once, when the upgrade first runs against your existing database,
   so keep the configuration in place through the upgrade.
   The migrated provider keeps using the redirect URI already registered in the Google Cloud Console,
-  so nothing changes on the Google side. Remove the variables after the provider appears in the admin panel.
+  so nothing changes on the Google side.
+  Keep `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` in place after the upgrade too:
+  the token-refresh path for signed-in users still reads them until their planned removal in `v4.5`.
+  `AUTH_TYPE` itself can be removed once the provider appears in the admin panel.
 </Note>
 
 For reference, a pre-`v4.4.0` configuration looks like:

--- a/deployment/authentication/oidc.mdx
+++ b/deployment/authentication/oidc.mdx
@@ -76,13 +76,12 @@ Please contact us if you need help with a different identity provider.
 ## Customizing requested scopes
 
 By default, Onyx uses the standard OIDC base scopes when redirecting users to the identity provider.
-Overriding the list is primarily useful when the access token issued at login should be passed through
-to tool calls that need additional scopes from the identity provider.
+Overriding the list is primarily useful when the access token issued at login should be passed through to tool calls
+that need additional scopes from the identity provider.
 
-Starting in `v4.5`, set **Scopes** on the provider entry
-(**Admin Panel** → **Organization** → **SSO Providers**) to override the list per provider.
-A provider's **Scopes** take precedence. When left empty, the deployment-wide
-environment variable applies, then the built-in defaults.
+Starting in `v4.5`, set **Scopes** on the provider entry (**Admin Panel** → **Organization** → **SSO Providers**)
+to override the list per provider. A provider's **Scopes** take precedence. When left empty,
+the deployment-wide environment variable applies, then the built-in defaults.
 
 On `v4.4.x`, the only override is the deployment-wide `OIDC_SCOPE_OVERRIDE` environment variable,
 a comma-separated list that applies to every OIDC provider:
@@ -108,8 +107,8 @@ Onyx will always also request `offline_access` so refresh tokens are issued, eve
 
 PKCE is disabled by default to preserve backwards compatibility with existing OIDC deployments.
 
-Starting in `v4.5`, turn on **Enable PKCE** on the provider entry
-(**Admin Panel** → **Organization** → **SSO Providers**).
+Starting in `v4.5`,
+turn on **Enable PKCE** on the provider entry (**Admin Panel** → **Organization** → **SSO Providers**).
 
 On `v4.4.x`, the deployment-wide `OIDC_PKCE_ENABLED` environment variable enables it for all providers:
 
@@ -118,9 +117,8 @@ OIDC_PKCE_ENABLED=true
 ```
 
 <Warning>
-  `OIDC_PKCE_ENABLED=true` forces PKCE on for every provider, including
-  providers whose **Enable PKCE** toggle is off. Unset it if you want the
-  per-provider toggles to be the source of truth.
+  `OIDC_PKCE_ENABLED=true` forces PKCE on for every provider, including providers whose **Enable PKCE** toggle is off.
+  Unset it if you want the per-provider toggles to be the source of truth.
 </Warning>
 
 ## Upgrading from v4.3 or Earlier
@@ -137,8 +135,8 @@ New installs must use the admin panel flow above.
   so keep the configuration in place through the upgrade.
   The migrated provider keeps using the redirect URI already registered with your IdP,
   so nothing changes on the IdP side. Once the migrated provider appears in the admin panel,
-  sign-ins and token refresh use the provider entry's credentials, and `AUTH_TYPE`,
-  `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, and `OPENID_CONFIG_URL` can be removed.
+  sign-ins and token refresh use the provider entry's credentials, and `AUTH_TYPE`, `OAUTH_CLIENT_ID`,
+  `OAUTH_CLIENT_SECRET`, and `OPENID_CONFIG_URL` can be removed.
   The variables only act as a fallback for login accounts that no provider entry matches,
   such as after deleting or renaming the migrated provider.
 </Note>

--- a/deployment/authentication/oidc.mdx
+++ b/deployment/authentication/oidc.mdx
@@ -76,15 +76,16 @@ Please contact us if you need help with a different identity provider.
 ## Customizing requested scopes
 
 By default, Onyx uses the standard OIDC base scopes when redirecting users to the identity provider.
-This is primarily useful when the access token issued at login should be passed through to tool calls that need
-additional scopes from the identity provider.
+Overriding the list is primarily useful when the access token issued at login should be passed through
+to tool calls that need additional scopes from the identity provider.
 
 Starting in `v4.5`, set **Scopes** on the provider entry
 (**Admin Panel** → **Organization** → **SSO Providers**) to override the list per provider.
+A provider's **Scopes** take precedence. When left empty, the deployment-wide
+environment variable applies, then the built-in defaults.
 
-On `v4.4.x`, the override is the deployment-wide `OIDC_SCOPE_OVERRIDE` environment variable,
-a comma-separated list that applies to every OIDC provider.
-It is planned for removal in `v4.5` in favor of the per-provider setting.
+On `v4.4.x`, the only override is the deployment-wide `OIDC_SCOPE_OVERRIDE` environment variable,
+a comma-separated list that applies to every OIDC provider:
 
 ```bash .env
 OIDC_SCOPE_OVERRIDE=openid,email,profile,groups
@@ -110,12 +111,17 @@ PKCE is disabled by default to preserve backwards compatibility with existing OI
 Starting in `v4.5`, turn on **Enable PKCE** on the provider entry
 (**Admin Panel** → **Organization** → **SSO Providers**).
 
-On `v4.4.x`, the deployment-wide environment variable enables it for all providers.
-It is planned for removal in `v4.5` in favor of the per-provider setting.
+On `v4.4.x`, the deployment-wide `OIDC_PKCE_ENABLED` environment variable enables it for all providers:
 
 ```bash .env
 OIDC_PKCE_ENABLED=true
 ```
+
+<Warning>
+  `OIDC_PKCE_ENABLED=true` forces PKCE on for every provider, including
+  providers whose **Enable PKCE** toggle is off. Unset it if you want the
+  per-provider toggles to be the source of truth.
+</Warning>
 
 ## Upgrading from v4.3 or Earlier
 
@@ -130,10 +136,11 @@ New installs must use the admin panel flow above.
   and existing logins keep working. The import runs once, when the upgrade first runs against your existing database,
   so keep the configuration in place through the upgrade.
   The migrated provider keeps using the redirect URI already registered with your IdP,
-  so nothing changes on the IdP side. Keep `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`,
-  and `OPENID_CONFIG_URL` in place after the upgrade too:
-  the token-refresh path for signed-in users still reads them until their planned removal in `v4.5`.
-  `AUTH_TYPE` itself can be removed once the provider appears in the admin panel.
+  so nothing changes on the IdP side. Once the migrated provider appears in the admin panel,
+  sign-ins and token refresh use the provider entry's credentials, and `AUTH_TYPE`,
+  `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, and `OPENID_CONFIG_URL` can be removed.
+  The variables only act as a fallback for login accounts that no provider entry matches,
+  such as after deleting or renaming the migrated provider.
 </Note>
 
 For reference, a pre-`v4.4.0` configuration looks like:

--- a/deployment/authentication/oidc.mdx
+++ b/deployment/authentication/oidc.mdx
@@ -76,9 +76,15 @@ Please contact us if you need help with a different identity provider.
 ## Customizing requested scopes
 
 By default, Onyx uses the standard OIDC base scopes when redirecting users to the identity provider.
-You can override this list with `OIDC_SCOPE_OVERRIDE`, a comma-separated list of scopes to request instead.
 This is primarily useful when the access token issued at login should be passed through to tool calls that need
 additional scopes from the identity provider.
+
+Starting in `v4.5`, set **Scopes** on the provider entry
+(**Admin Panel** → **Organization** → **SSO Providers**) to override the list per provider.
+
+On `v4.4.x`, the override is the deployment-wide `OIDC_SCOPE_OVERRIDE` environment variable,
+a comma-separated list that applies to every OIDC provider.
+It is planned for removal in `v4.5` in favor of the per-provider setting.
 
 ```bash .env
 OIDC_SCOPE_OVERRIDE=openid,email,profile,groups
@@ -99,7 +105,13 @@ Onyx will always also request `offline_access` so refresh tokens are issued, eve
 
 ## Enabling PKCE
 
-PKCE is disabled by default to preserve backwards compatibility with existing OIDC deployments. To enable it, set:
+PKCE is disabled by default to preserve backwards compatibility with existing OIDC deployments.
+
+Starting in `v4.5`, turn on **Enable PKCE** on the provider entry
+(**Admin Panel** → **Organization** → **SSO Providers**).
+
+On `v4.4.x`, the deployment-wide environment variable enables it for all providers.
+It is planned for removal in `v4.5` in favor of the per-provider setting.
 
 ```bash .env
 OIDC_PKCE_ENABLED=true

--- a/deployment/authentication/oidc.mdx
+++ b/deployment/authentication/oidc.mdx
@@ -118,7 +118,10 @@ New installs must use the admin panel flow above.
   and existing logins keep working. The import runs once, when the upgrade first runs against your existing database,
   so keep the configuration in place through the upgrade.
   The migrated provider keeps using the redirect URI already registered with your IdP,
-  so nothing changes on the IdP side. Remove the variables after the provider appears in the admin panel.
+  so nothing changes on the IdP side. Keep `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`,
+  and `OPENID_CONFIG_URL` in place after the upgrade too:
+  the token-refresh path for signed-in users still reads them until their planned removal in `v4.5`.
+  `AUTH_TYPE` itself can be removed once the provider appears in the admin panel.
 </Note>
 
 For reference, a pre-`v4.4.0` configuration looks like:

--- a/deployment/authentication/sso_providers.mdx
+++ b/deployment/authentication/sso_providers.mdx
@@ -24,7 +24,10 @@ so one Onyx instance can serve teams on different identity providers.
   The import runs once, when the upgrade first runs against your existing database,
   so keep the legacy configuration in place through the upgrade.
   Migrated providers keep using the redirect URIs and ACS URLs already registered with your identity provider,
-  so nothing changes on the IdP side. Remove the legacy variables after the provider appears in the admin panel.
+  so nothing changes on the IdP side. For Google and OIDC,
+  keep the OAuth credential variables in place after the upgrade too,
+  since the token-refresh path for signed-in users still reads them until their planned removal in `v4.5`.
+  `AUTH_TYPE` and, for SAML, the settings file can be removed once the provider appears in the admin panel.
 </Note>
 
 ## Managing Providers

--- a/deployment/authentication/sso_providers.mdx
+++ b/deployment/authentication/sso_providers.mdx
@@ -57,6 +57,11 @@ Navigate to **Admin Panel** → **Organization** → **SSO Providers**.
 
     Optionally restrict the provider to specific **email domains**.
     Users outside those domains cannot sign in through it.
+
+    OIDC entries also expose a **Require Verified Email Claim** toggle for IdPs
+    that send the optional `email_verified` claim. Starting in `v4.5`, Google and
+    OIDC entries additionally offer **Enable PKCE** and a per-provider **Scopes**
+    override, replacing the deployment-wide environment variables.
   </Step>
 
   <Step title="Register the Callback with your Identity Provider">
@@ -69,6 +74,22 @@ Navigate to **Admin Panel** → **Organization** → **SSO Providers**.
     Use the toggle on the provider row to disable or re-enable it later.
   </Step>
 </Steps>
+
+## Turning Off Password Login
+
+Once SSO works, you can close password login and sign-up entirely so your
+identity provider is the only way in. Go to **Admin Panel** → **Security &
+Hardening** and turn on **Disable Password Login & Signup**.
+
+- The save is refused unless at least one SSO provider is enabled, so you
+  cannot lock yourself out.
+- With the switch on, the login page shows only the SSO sign-in options,
+  the sign-up page redirects to login, and password sign-in is refused by the
+  backend regardless of how it is called.
+- Disabling the last enabled SSO provider is refused while the switch is on.
+- Self-hosted (single-tenant) deployments only.
+
+Available starting in `v4.5`, and backported to the `v4.4` line.
 
 ## Plan Availability
 

--- a/deployment/authentication/sso_providers.mdx
+++ b/deployment/authentication/sso_providers.mdx
@@ -25,9 +25,9 @@ so one Onyx instance can serve teams on different identity providers.
   so keep the legacy configuration in place through the upgrade.
   Migrated providers keep using the redirect URIs and ACS URLs already registered with your identity provider,
   so nothing changes on the IdP side. Once the migrated provider appears in the admin panel,
-  sign-ins and token refresh use the provider entry's credentials,
-  and the legacy variables (`AUTH_TYPE`, the OAuth credential variables, and for SAML the settings file)
-  can be removed. The variables only act as a fallback for login accounts that no provider entry matches,
+  sign-ins and token refresh use the provider entry's credentials, and the legacy variables (`AUTH_TYPE`,
+  the OAuth credential variables, and for SAML the settings file) can be removed.
+  The variables only act as a fallback for login accounts that no provider entry matches,
   such as after deleting or renaming the migrated provider.
 </Note>
 
@@ -59,12 +59,11 @@ Navigate to **Admin Panel** → **Organization** → **SSO Providers**.
     Optionally restrict the provider to specific **email domains**.
     Users outside those domains cannot sign in through it.
 
-    OIDC entries also expose a **Require Verified Email Claim** toggle for IdPs
-    that send the optional `email_verified` claim. Starting in `v4.5`, Google and
-    OIDC entries additionally offer **Enable PKCE** and a per-provider **Scopes**
-    override, taking precedence over the deployment-wide environment variables.
-    See [Customizing requested scopes](/deployment/authentication/oidc#customizing-requested-scopes)
-    for the details.
+    OIDC entries also expose a **Require Verified Email Claim** toggle for IdPs that send the optional `email_verified`
+    claim. Starting in `v4.5`,
+    Google and OIDC entries additionally offer **Enable PKCE** and a per-provider **Scopes** override,
+    taking precedence over the deployment-wide environment variables.
+    See [Customizing requested scopes](/deployment/authentication/oidc#customizing-requested-scopes) for the details.
   </Step>
 
   <Step title="Register the Callback with your Identity Provider">
@@ -84,15 +83,13 @@ Navigate to **Admin Panel** → **Organization** → **SSO Providers**.
   Available in `v4.5` and in `v4.4` patch releases after `v4.4.5`.
 </Note>
 
-Once SSO works, you can close password login and sign-up entirely so your
-identity provider is the only way in. Go to **Admin Panel** → **Organization**
-→ **Security & Hardening** and turn on **Disable Password Login & Signup**.
+Once SSO works, you can close password login and sign-up entirely so your identity provider is the only way in.
+Go to **Admin Panel** → **Organization** → **Security & Hardening** and turn on **Disable Password Login & Signup**.
 
 - The save is refused unless at least one SSO provider is enabled, so you
   cannot lock yourself out.
 - With the switch on, the login page shows only the SSO sign-in options,
-  the sign-up page redirects to login, and password sign-in is refused by the
-  backend regardless of how it is called.
+  the sign-up page redirects to login, and password sign-in is refused by the backend regardless of how it is called.
 - Disabling the last enabled SSO provider is refused while the switch is on.
 - Self-hosted (single-tenant) deployments only.
 

--- a/deployment/authentication/sso_providers.mdx
+++ b/deployment/authentication/sso_providers.mdx
@@ -24,10 +24,11 @@ so one Onyx instance can serve teams on different identity providers.
   The import runs once, when the upgrade first runs against your existing database,
   so keep the legacy configuration in place through the upgrade.
   Migrated providers keep using the redirect URIs and ACS URLs already registered with your identity provider,
-  so nothing changes on the IdP side. For Google and OIDC,
-  keep the OAuth credential variables in place after the upgrade too,
-  since the token-refresh path for signed-in users still reads them until their planned removal in `v4.5`.
-  `AUTH_TYPE` and, for SAML, the settings file can be removed once the provider appears in the admin panel.
+  so nothing changes on the IdP side. Once the migrated provider appears in the admin panel,
+  sign-ins and token refresh use the provider entry's credentials,
+  and the legacy variables (`AUTH_TYPE`, the OAuth credential variables, and for SAML the settings file)
+  can be removed. The variables only act as a fallback for login accounts that no provider entry matches,
+  such as after deleting or renaming the migrated provider.
 </Note>
 
 ## Managing Providers
@@ -61,7 +62,9 @@ Navigate to **Admin Panel** → **Organization** → **SSO Providers**.
     OIDC entries also expose a **Require Verified Email Claim** toggle for IdPs
     that send the optional `email_verified` claim. Starting in `v4.5`, Google and
     OIDC entries additionally offer **Enable PKCE** and a per-provider **Scopes**
-    override, replacing the deployment-wide environment variables.
+    override, taking precedence over the deployment-wide environment variables.
+    See [Customizing requested scopes](/deployment/authentication/oidc#customizing-requested-scopes)
+    for the details.
   </Step>
 
   <Step title="Register the Callback with your Identity Provider">
@@ -77,9 +80,13 @@ Navigate to **Admin Panel** → **Organization** → **SSO Providers**.
 
 ## Turning Off Password Login
 
+<Note>
+  Available in `v4.5` and in `v4.4` patch releases after `v4.4.5`.
+</Note>
+
 Once SSO works, you can close password login and sign-up entirely so your
-identity provider is the only way in. Go to **Admin Panel** → **Security &
-Hardening** and turn on **Disable Password Login & Signup**.
+identity provider is the only way in. Go to **Admin Panel** → **Organization**
+→ **Security & Hardening** and turn on **Disable Password Login & Signup**.
 
 - The save is refused unless at least one SSO provider is enabled, so you
   cannot lock yourself out.
@@ -88,8 +95,6 @@ Hardening** and turn on **Disable Password Login & Signup**.
   backend regardless of how it is called.
 - Disabling the last enabled SSO provider is refused while the switch is on.
 - Self-hosted (single-tenant) deployments only.
-
-Available starting in `v4.5`, and backported to the `v4.4` line.
 
 ## Plan Availability
 

--- a/deployment/configuration/configuration.mdx
+++ b/deployment/configuration/configuration.mdx
@@ -309,7 +309,8 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
   </Accordion>
 
   <Accordion title="Authentication & Security">
-    `AUTH_TYPE`: Authentication type (disabled, basic, oauth, etc.)
+    `AUTH_TYPE`: Legacy (pre-`v4.4.0`). Authentication is always enabled and SSO is configured in the admin panel,
+    so the variable is inert. Planned for full removal in `v4.5`.
 
     `PASSWORD_MIN_LENGTH`: For basic auth. The minimum password length requirement
 
@@ -347,13 +348,13 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
 
     `OPENID_CONFIG_URL`: For OIDC.
 
-    `GOOGLE_OAUTH_SCOPE_OVERRIDE`: For Google OAuth login (`AUTH_TYPE=google_oauth` or `cloud`).
+    `GOOGLE_OAUTH_SCOPE_OVERRIDE`: For Google login.
     Comma-separated list of scopes to request from Google instead of the defaults (`openid,email,profile`).
     Useful when the access token from login needs to be passed through to tool calls that require additional Google API
     scopes (i.e. when using Pass-Through OAuth for an MCP server).
     Any scopes added here must also be enabled on the OAuth client in Google Cloud Console.
 
-    `OIDC_SCOPE_OVERRIDE`: For OIDC login (`AUTH_TYPE=oidc`).
+    `OIDC_SCOPE_OVERRIDE`: For OIDC login.
     Comma-separated list of scopes to request from the OIDC provider instead of the defaults.
     Same use case as `GOOGLE_OAUTH_SCOPE_OVERRIDE`.
 

--- a/snippets/install-onyx.mdx
+++ b/snippets/install-onyx.mdx
@@ -17,10 +17,10 @@
     # If your email is something like "chris@onyx.app", then this should be "onyx.app"
     # This prevents people outside your company from creating an account
     VALID_EMAIL_DOMAINS=<YOUR_COMPANIES_EMAIL_DOMAIN>
-
-    # See our auth guides for options here
-    AUTH_TYPE=
     ```
+
+    Email/password login works out of the box, and SSO (Google / OIDC / SAML) is configured later from the admin panel.
+    See our [auth guides](/deployment/authentication/basic) for details.
 
     ```bash .env.nginx
     DOMAIN=<YOUR_DOMAIN>  # Something like "onyx.app"


### PR DESCRIPTION
Follow-up to #413. Brings the auth docs in line with what actually ships.

- Upgrade notes (Google, OIDC, SSO Providers): once the migrated provider appears in the admin panel, sign-ins and token refresh use the provider entry's credentials (the refresher resolves the provider row first since #13346, which is on the v4.4 line). The legacy env vars only act as a fallback for login accounts no provider entry matches, and can otherwise be removed. Also fixes the variable names the Google page told upgraders to keep (`OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET`, matching the documented pre-v4.4 setup).
- New "Turning Off Password Login" section: the **Disable Password Login & Signup** toggle on Security & Hardening, its lockout guards, and availability (`v4.5`, and `v4.4` patch releases after `v4.4.5`).
- Scopes and PKCE sections now document the `v4.5` per-provider settings with the real precedence (provider entry wins, env var is the deployment-wide fallback, `OIDC_PKCE_ENABLED=true` force-enables PKCE even when a provider's toggle is off). The Google page gains its own Enabling PKCE section.
- Retires the `AUTH_TYPE=basic` setup story: the Basic Auth page now says auth is always on (no setup, first user is admin) with the real 8-64 password defaults and the Security & Hardening pointer, the install quickstart no longer asks for `AUTH_TYPE=`, and the configuration reference marks `AUTH_TYPE` legacy/inert.
