### PR TITLE
docs(changelog): expand v4.4.0 deployment-change upgrade steps

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -50,19 +50,17 @@ rss: true
   </Note>
 
   - **Drop `command:` / `entrypoint:` overrides for these two images.** Both the web and model-server images now bake
-    in their own entrypoint and — having no shell — can no longer run a `command:` / `entrypoint:` that wraps startup in
-    `/bin/sh -c`. Remove any such override from your customized files so the image's own entrypoint runs;
+    in their own entrypoint and can no longer run a `command:` / `entrypoint:` that wraps startup in `/bin/sh -c`.
+    Remove any such override from your customized files so the image's own entrypoint runs;
     this includes the old model-server `DISABLE_MODEL_SERVER` gate, now handled inside the image.
-    If you used a shell wrapper only to set an environment variable — for example forcing the web server's `HOSTNAME` —
-    set it as a plain container environment variable instead.
-    (The API server and background images are not hardened and still rely on their stock `/bin/sh -c` commands — leave
-    those as-is.)
+      - The API server and background images are not hardened and still rely on their stock `/bin/sh -c` commands — leave
+        those as-is.
   - **Custom CA roots on the model server.** The old shell `update-ca-certificates` step is gone. Mount your
     certificates into a directory and set `ONYX_CUSTOM_CA_CERTS_DIR` to that path (files must end in `.crt` or `.pem`);
     they are merged on top of the public roots when the model server starts. On Helm, upgrade the chart (≥ `0.7.0`)
     and the image **together** — the chart mounts the certs and sets the variable for you. After upgrading,
     confirm the `Trusting N custom CA file(s)` line in the model-server logs.
-    The API server and background containers are unchanged (they still read `/etc/ssl/certs/custom-ca.crt`).
+      - The API server and background containers are unchanged (they still read `/etc/ssl/certs/custom-ca.crt`).
 
   ## Key Improvements
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -16,7 +16,7 @@ rss: true
   and Google Drive and Gmail support multiple connectors with independent credentials.
   Thank you to our contributors for helping make this release possible!
 
-  ## [Update] Deployment Changes
+  ## [Update] Action May Be Required
 
   ### `AUTH_TYPE` has been removed — SSO moves to the admin panel
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -45,7 +45,8 @@ rss: true
   and they run as a non-root user.
 
   <Note>
-    The latest versions of the Docker Compose files and Helm chart (≥ `0.7.0`) include these changes and can be used instead of migrating.
+    The latest versions of the Docker Compose files and Helm chart (≥ `0.7.0`)
+    include these changes and can be used instead of migrating.
     The steps below can be used to update legacy deployments in-place.
   </Note>
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -59,7 +59,6 @@ rss: true
     The API server and background containers are unchanged (they still read `/etc/ssl/certs/custom-ca.crt`).
   - **Shell-wrapped overrides on the web container.** Because the web image has
     no shell, a `command:` / `entrypoint:` override that wraps startup in `/bin/sh -c` no longer runs.
-    If you patched a value such as `HOSTNAME` that way, set it as a plain container environment variable instead.
 
   ### Customized Docker Compose files
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -18,12 +18,6 @@ rss: true
 
   ## [Update] Deployment Changes
 
-  <Note>
-    The stock Docker Compose and Helm files already carry every change below,
-    so pulling the latest and redeploying picks them up.
-    Read this section closely if you maintain a customized copy of those files, run SSO, or mount custom CA roots.
-  </Note>
-
   ### `AUTH_TYPE` has been removed — SSO moves to the admin panel
 
   SSO is now configured from **Admin Panel → Organization → [SSO
@@ -48,24 +42,27 @@ rss: true
   ### Hardened, non-root model server and web images
 
   The model server and web frontend now build on distroless, hardened images: no shell or package manager,
-  and they run as a non-root user. Default deployments need no changes, but two customizations are affected:
+  and they run as a non-root user.
 
-  - **Custom CA roots on the model server.** The old shell `update-ca-certificates`
-    step is gone.
-    Mount your certificates into a directory and set `ONYX_CUSTOM_CA_CERTS_DIR` to that path (files must end in `.crt`
-    or `.pem`); they are merged on top of the public roots when the model server starts. On Helm,
-    upgrade the chart (≥ `0.7.0`) and the image **together** — the chart mounts the certs and sets the variable for you.
-    After upgrading, confirm the `Trusting N custom CA file(s)` line in the model-server logs.
+  <Note>
+    Upgrading the stock Helm chart (≥ `0.7.0`) or Docker Compose files carries these changes for you.
+    You only need the steps below if you maintain a customized copy of those files or mount custom CA roots.
+  </Note>
+
+  - **Drop `command:` / `entrypoint:` overrides for these two images.** Both the web and model-server images now bake
+    in their own entrypoint and — having no shell — can no longer run a `command:` / `entrypoint:` that wraps startup in
+    `/bin/sh -c`. Remove any such override from your customized files so the image's own entrypoint runs;
+    this includes the old model-server `DISABLE_MODEL_SERVER` gate, now handled inside the image.
+    If you used a shell wrapper only to set an environment variable — for example forcing the web server's `HOSTNAME` —
+    set it as a plain container environment variable instead.
+    (The API server and background images are not hardened and still rely on their stock `/bin/sh -c` commands — leave
+    those as-is.)
+  - **Custom CA roots on the model server.** The old shell `update-ca-certificates` step is gone. Mount your
+    certificates into a directory and set `ONYX_CUSTOM_CA_CERTS_DIR` to that path (files must end in `.crt` or `.pem`);
+    they are merged on top of the public roots when the model server starts. On Helm, upgrade the chart (≥ `0.7.0`)
+    and the image **together** — the chart mounts the certs and sets the variable for you. After upgrading,
+    confirm the `Trusting N custom CA file(s)` line in the model-server logs.
     The API server and background containers are unchanged (they still read `/etc/ssl/certs/custom-ca.crt`).
-  - **Shell-wrapped overrides on the web container.** Because the web image has
-    no shell, a `command:` / `entrypoint:` override that wraps startup in `/bin/sh -c` no longer runs.
-
-  ### Customized Docker Compose files
-
-  If you fork the Compose files,
-  note that the `inference_model_server` and `indexing_model_server` services no longer take a `/bin/sh -c` command to
-  gate `DISABLE_MODEL_SERVER` — that logic moved into the image, which (being distroless) has no shell to run it.
-  Remove the stale `command:` from your copy so it falls back to the image default.
 
   ## Key Improvements
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -47,7 +47,7 @@ rss: true
   <Note>
     The latest versions of the Docker Compose files and Helm chart (≥ `0.7.0`)
     include these changes and can be used instead of migrating.
-    The steps below can be used to update legacy deployments in-place.
+    The steps below can be used to update legacy deployments in place.
   </Note>
 
   - **Drop `command:` / `entrypoint:` overrides for these two images.** Both the web and model-server images now bake

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -45,8 +45,8 @@ rss: true
   and they run as a non-root user.
 
   <Note>
-    Upgrading the stock Helm chart (≥ `0.7.0`) or Docker Compose files carries these changes for you.
-    You only need the steps below if you maintain a customized copy of those files or mount custom CA roots.
+    The latest versions of the Docker Compose files and Helm chart (≥ `0.7.0`) include these changes and can be used instead of migrating.
+    The steps below can be used to update legacy deployments in-place.
   </Note>
 
   - **Drop `command:` / `entrypoint:` overrides for these two images.** Both the web and model-server images now bake

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -53,14 +53,14 @@ rss: true
     in their own entrypoint and can no longer run a `command:` / `entrypoint:` that wraps startup in `/bin/sh -c`.
     Remove any such override from your customized files so the image's own entrypoint runs;
     this includes the old model-server `DISABLE_MODEL_SERVER` gate, now handled inside the image.
-      - The API server and background images are not hardened and still rely on their stock `/bin/sh -c` commands — leave
-        those as-is.
+    The API server and background images are not hardened and still rely on their stock `/bin/sh -c` commands — leave
+    those as-is.
   - **Custom CA roots on the model server.** The old shell `update-ca-certificates` step is gone. Mount your
     certificates into a directory and set `ONYX_CUSTOM_CA_CERTS_DIR` to that path (files must end in `.crt` or `.pem`);
     they are merged on top of the public roots when the model server starts. On Helm, upgrade the chart (≥ `0.7.0`)
     and the image **together** — the chart mounts the certs and sets the variable for you. After upgrading,
     confirm the `Trusting N custom CA file(s)` line in the model-server logs.
-      - The API server and background containers are unchanged (they still read `/etc/ssl/certs/custom-ca.crt`).
+    The API server and background containers are unchanged (they still read `/etc/ssl/certs/custom-ca.crt`).
 
   ## Key Improvements
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -18,14 +18,55 @@ rss: true
 
   ## [Update] Deployment Changes
 
-  - **`AUTH_TYPE` has been removed.** SSO providers are now rows managed
-    from the admin UI. On upgrade,
-    your existing env-based SSO config is automatically seeded into provider rows that keep sending the exact redirect
-    URIs your IdP already allowlists — no OAuth client changes are needed.
-    Legacy `AUTH_TYPE` values are ignored with a startup warning.
-  - **The model server and web frontend now build on hardened distroless
-    images.** Custom CA certificates are merged in the entrypoint; if you mount custom roots,
-    verify them after upgrading.
+  <Note>
+    The stock Docker Compose and Helm files already carry every change below,
+    so pulling the latest and redeploying picks them up.
+    Read this section closely if you maintain a customized copy of those files, run SSO, or mount custom CA roots.
+  </Note>
+
+  ### `AUTH_TYPE` has been removed — SSO moves to the admin panel
+
+  SSO is now configured from **Admin Panel → Organization → [SSO
+  Providers](https://docs.onyx.app/deployment/authentication/sso_providers)** instead of environment variables.
+  On the first upgraded startup,
+  a one-time migration seeds your existing `AUTH_TYPE` / OAuth / OIDC configuration into a provider row that keeps the
+  exact redirect and ACS URLs your identity provider already allowlists — no OAuth client changes are needed.
+  **Keep the legacy variables in place through the upgrade** so the migration can read them.
+
+  After upgrading, confirm the provider appears under **SSO Providers** and that logins still work,
+  then remove `AUTH_TYPE` and the legacy SSO variables — they are now inert and only emit a startup warning (the value
+  still shipped in `env.template` is likewise inert).
+  See the [OIDC upgrade notes](https://docs.onyx.app/deployment/authentication/oidc) for a full before/after.
+
+  <Warning>
+    If you previously ran SSO-only, the login page now also renders an email/password form alongside your SSO button(s).
+    To stop un-invited people from registering,
+    enable **Restrict Open Sign-Up** under **Admin Panel → Permissions → Users** — un-invited emails are then rejected
+    at sign-in until an admin invites them.
+  </Warning>
+
+  ### Hardened, non-root model server and web images
+
+  The model server and web frontend now build on distroless, hardened images: no shell or package manager,
+  and they run as a non-root user. Default deployments need no changes, but two customizations are affected:
+
+  - **Custom CA roots on the model server.** The old shell `update-ca-certificates`
+    step is gone.
+    Mount your certificates into a directory and set `ONYX_CUSTOM_CA_CERTS_DIR` to that path (files must end in `.crt`
+    or `.pem`); they are merged on top of the public roots when the model server starts. On Helm,
+    upgrade the chart (≥ `0.7.0`) and the image **together** — the chart mounts the certs and sets the variable for you.
+    After upgrading, confirm the `Trusting N custom CA file(s)` line in the model-server logs.
+    The API server and background containers are unchanged (they still read `/etc/ssl/certs/custom-ca.crt`).
+  - **Shell-wrapped overrides on the web container.** Because the web image has
+    no shell, a `command:` / `entrypoint:` override that wraps startup in `/bin/sh -c` no longer runs.
+    If you patched a value such as `HOSTNAME` that way, set it as a plain container environment variable instead.
+
+  ### Customized Docker Compose files
+
+  If you fork the Compose files,
+  note that the `inference_model_server` and `indexing_model_server` services no longer take a `/bin/sh -c` command to
+  gate `DISABLE_MODEL_SERVER` — that logic moved into the image, which (being distroless) has no shell to run it.
+  Remove the stale `command:` from your copy so it falls back to the image default.
 
   ## Key Improvements
 


### PR DESCRIPTION
## Summary

Prompted by onyx-dot-app/onyx#13319 ("Better update / migration notes"), the v4.4.0 **Deployment Changes** section described *what changed* but not *what an upgrader must do*. This rewrites it into action-oriented subsections, matching the v4.1.1 "Action May Be Required" style already in the changelog.

## Changes

- **`AUTH_TYPE` removal** — keep the legacy vars in place through the one-time migration, verify the seeded SSO provider + logins, then remove them. Adds a `<Warning>` that the login page now shows a password form as a fallback, pointing to **Restrict Open Sign-Up** to gate registration (directly addresses the "random signups" complaint in the issue).
- **Hardened model server / web images** — corrects the vague "merged in the entrypoint" wording: custom CA roots now go through `ONYX_CUSTOM_CA_CERTS_DIR` (the old `update-ca-certificates` shell step is gone), and shell-wrapped web-container overrides (e.g. `HOSTNAME`) must move to plain env vars since the distroless image has no shell.
- **Customized Compose files** — notes that the `DISABLE_MODEL_SERVER` `/bin/sh -c` gate was removed from the model-server services and now lives in the image; stock files just need a pull.

Leads with a `<Note>` clarifying that stock Compose/Helm files already carry these changes, so most operators only need a pull.

## Notes for reviewers

- The "Restrict Open Sign-Up" `<Warning>` documents a mitigation for what is currently a **bug** (the password form is a permanent fallback and isn't hidden when SSO providers exist). If a real fix lands that hides the form, this Warning should be softened/removed.
- Deliberately left the Craft/`SANDBOX_*` churn out — that's a background-container code issue (the idle-sandbox task registers regardless of `ENABLE_CRAFT`), not a documentable upgrade step.

Refs onyx-dot-app/onyx#13319

🤖 Generated with [Claude Code](https://claude.com/claude-code)