### PR TITLE
docs(agent-wiki): add Agent Wiki pages behind a hidden nav tab

### DIFF
--- a/agent-wiki/agent.mdx
+++ b/agent-wiki/agent.mdx
@@ -1,0 +1,9 @@
+---
+title: "Agent"
+description: "Configuring agents in Agent Wiki"
+icon: "robot"
+---
+
+<Note>
+  This page is a stub. Document Agent here.
+</Note>

--- a/agent-wiki/analytics.mdx
+++ b/agent-wiki/analytics.mdx
@@ -1,0 +1,9 @@
+---
+title: "Analytics"
+description: "Usage and activity analytics"
+icon: "chart-column"
+---
+
+<Note>
+  This page is a stub. Document Analytics here.
+</Note>

--- a/agent-wiki/assistant.mdx
+++ b/agent-wiki/assistant.mdx
@@ -1,0 +1,9 @@
+---
+title: "Assistant"
+description: "The Agent Wiki assistant"
+icon: "message-bot"
+---
+
+<Note>
+  This page is a stub. Document the Assistant here.
+</Note>

--- a/agent-wiki/editor.mdx
+++ b/agent-wiki/editor.mdx
@@ -1,0 +1,9 @@
+---
+title: "Editor"
+description: "Co-editing documents with humans and agents"
+icon: "pen-to-square"
+---
+
+<Note>
+  This page is a stub. Document the Editor here.
+</Note>

--- a/agent-wiki/home.mdx
+++ b/agent-wiki/home.mdx
@@ -1,0 +1,9 @@
+---
+title: "Home"
+description: "The Agent Wiki home view"
+icon: "house"
+---
+
+<Note>
+  This page is a stub. Document the Home view here.
+</Note>

--- a/agent-wiki/mcp.mdx
+++ b/agent-wiki/mcp.mdx
@@ -1,0 +1,9 @@
+---
+title: "MCP"
+description: "The Agent Wiki MCP server"
+icon: "plug"
+---
+
+<Note>
+  This page is a stub. Document the MCP server here.
+</Note>

--- a/agent-wiki/quickstart.mdx
+++ b/agent-wiki/quickstart.mdx
@@ -1,0 +1,13 @@
+---
+title: "Quickstart"
+description: "Set up your first Agent Wiki space"
+icon: "rocket"
+---
+
+<Note>
+  This page is a stub. Add quickstart steps here.
+</Note>
+
+## Overview
+
+Walk through creating a space, adding your first document, and connecting an agent.

--- a/agent-wiki/settings.mdx
+++ b/agent-wiki/settings.mdx
@@ -1,0 +1,9 @@
+---
+title: "Settings"
+description: "Configuring your Agent Wiki"
+icon: "gear"
+---
+
+<Note>
+  This page is a stub. Document Settings here.
+</Note>

--- a/agent-wiki/welcome.mdx
+++ b/agent-wiki/welcome.mdx
@@ -1,0 +1,29 @@
+---
+title: "Welcome to Agent Wiki"
+description: "A shared collaboration space for humans and agents"
+icon: "house"
+---
+
+## What is Agent Wiki?
+
+Agent Wiki is a shared collaboration space for humans and AI agents — a living source of truth for status, knowledge,
+and progress across ongoing work. Documents are markdown organized as a file hierarchy,
+editable by both people and agents.
+
+<Note>
+  **Agent Wiki and Onyx.** Agent Wiki is a distinct product built by the Onyx team.
+  It shares the Onyx brand and ecosystem, but it is not the Onyx product — it has its own concepts, interface, and docs.
+  These pages cover Agent Wiki only. For the Onyx platform, switch to **Onyx** in the selector above.
+</Note>
+
+## Quickstart
+
+<Columns cols={2}>
+  <Card title="Get Started" icon="rocket" href="/agent-wiki/quickstart">
+    Set up your first wiki space and invite agents in minutes.
+  </Card>
+
+  <Card title="The Editor" icon="pen-to-square" href="/agent-wiki/editor">
+    Learn how humans and agents co-edit documents.
+  </Card>
+</Columns>

--- a/agent-wiki/workflows.mdx
+++ b/agent-wiki/workflows.mdx
@@ -1,0 +1,9 @@
+---
+title: "Workflows"
+description: "Automating work in Agent Wiki"
+icon: "diagram-project"
+---
+
+<Note>
+  This page is a stub. Document Workflows here.
+</Note>

--- a/docs.json
+++ b/docs.json
@@ -596,6 +596,37 @@
         "tab": "Changelog",
         "icon": "clock-rotate-left",
         "pages": ["changelog"]
+      },
+      {
+        "tab": "Agent Wiki",
+        "icon": "book",
+        "hidden": true,
+        "pages": [
+          {
+            "group": "Getting Started",
+            "pages": ["agent-wiki/welcome", "agent-wiki/quickstart"]
+          },
+          {
+            "group": "Core",
+            "pages": [
+              "agent-wiki/home",
+              "agent-wiki/editor",
+              "agent-wiki/analytics"
+            ]
+          },
+          {
+            "group": "Automate",
+            "pages": [
+              "agent-wiki/workflows",
+              "agent-wiki/agent",
+              "agent-wiki/assistant"
+            ]
+          },
+          {
+            "group": "Admin",
+            "pages": ["agent-wiki/mcp", "agent-wiki/settings"]
+          }
+        ]
       }
     ],
     "global": {


### PR DESCRIPTION
## Description

Adds the initial Agent Wiki documentation set (10 pages: welcome, quickstart, home, editor, analytics, workflows, agent, assistant, mcp, settings) under a navigation tab marked `"hidden": true`.

The tab does not render in the top nav, so nothing changes for readers today, but every page is reachable by URL — this lets us draft and share the section before launch. Removing the `"hidden"` flag publishes it.

Note: the pages are intentionally stubs (frontmatter, a `<Note>` placeholder, and a one-line overview) so the structure and URLs can land first and content can fill in incrementally.

## How Has This Been Tested?

Ran `mintlify dev` locally and checked the rendered HTML:

- All 10 `/agent-wiki/*` URLs return 200, with the full four-group sidebar.
- The tab bar on a normal page (`/welcome`) renders Overview, Deployment, Admins, Developers, Security, Changelog — no Agent Wiki entry.
- `scripts/format_docs.py --check` passes; `mintlify broken-links` reports no broken links.

Two caveats worth noting for reviewers:

- Hidden is not private — anyone with a URL can read these pages. Per Mintlify, hidden pages are excluded from site search, the sitemap, and search-engine indexing by default.
- Once you are on an `/agent-wiki/*` page, the Agent Wiki tab does appear in the tab bar (that is how Mintlify hidden tabs work — you need it to navigate back out).
<img width="1691" height="979" alt="Screenshot 2026-07-28 at 1 44 15 PM" src="https://github.com/user-attachments/assets/3f30da33-13b8-4767-8914-a2e6a054a984" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check