### PR TITLE
docs(agent-wiki): align page structure with the product, add MCP and Compose guides

### DIFF
--- a/agent-wiki/admin/language_models.mdx
+++ b/agent-wiki/admin/language_models.mdx
@@ -1,0 +1,9 @@
+---
+title: "Language Models"
+description: "Configure the LLM provider powering the wiki"
+icon: "microchip"
+---
+
+<Note>
+  This page is a stub. Document language model configuration here.
+</Note>

--- a/agent-wiki/admin/notifications.mdx
+++ b/agent-wiki/admin/notifications.mdx
@@ -1,0 +1,9 @@
+---
+title: "Notifications"
+description: "Slack app and outbound email delivery"
+icon: "bell"
+---
+
+<Note>
+  This page is a stub. Document notification delivery here.
+</Note>

--- a/agent-wiki/admin/onyx_integration.mdx
+++ b/agent-wiki/admin/onyx_integration.mdx
@@ -1,0 +1,9 @@
+---
+title: "Onyx Integration"
+description: "Push documents from Onyx into the wiki"
+icon: "plug"
+---
+
+<Note>
+  This page is a stub. Document the Onyx integration here.
+</Note>

--- a/agent-wiki/admin/overview.mdx
+++ b/agent-wiki/admin/overview.mdx
@@ -1,0 +1,9 @@
+---
+title: "Admin Overview"
+description: "The Agent Wiki admin console"
+icon: "user-shield"
+---
+
+<Note>
+  This page is a stub. Document the admin console here.
+</Note>

--- a/agent-wiki/admin/status.mdx
+++ b/agent-wiki/admin/status.mdx
@@ -1,0 +1,9 @@
+---
+title: "Status & Usage"
+description: "System health and usage tracking"
+icon: "chart-line"
+---
+
+<Note>
+  This page is a stub. Document status and usage tracking here.
+</Note>

--- a/agent-wiki/admin/templates.mdx
+++ b/agent-wiki/admin/templates.mdx
@@ -1,0 +1,9 @@
+---
+title: "Wiki Templates"
+description: "Starter templates for new pages"
+icon: "file-lines"
+---
+
+<Note>
+  This page is a stub. Document templates here.
+</Note>

--- a/agent-wiki/admin/users_and_groups.mdx
+++ b/agent-wiki/admin/users_and_groups.mdx
@@ -1,0 +1,9 @@
+---
+title: "Users & Groups"
+description: "Accounts, roles, and permission groups"
+icon: "users"
+---
+
+<Note>
+  This page is a stub. Document users and groups here.
+</Note>

--- a/agent-wiki/agent.mdx
+++ b/agent-wiki/agent.mdx
@@ -1,9 +1,0 @@
----
-title: "Agent"
-description: "Configuring agents in Agent Wiki"
-icon: "robot"
----
-
-<Note>
-  This page is a stub. Document Agent here.
-</Note>

--- a/agent-wiki/analytics.mdx
+++ b/agent-wiki/analytics.mdx
@@ -1,9 +1,0 @@
----
-title: "Analytics"
-description: "Usage and activity analytics"
-icon: "chart-column"
----
-
-<Note>
-  This page is a stub. Document Analytics here.
-</Note>

--- a/agent-wiki/assistant.mdx
+++ b/agent-wiki/assistant.mdx
@@ -1,9 +1,0 @@
----
-title: "Assistant"
-description: "The Agent Wiki assistant"
-icon: "message-bot"
----
-
-<Note>
-  This page is a stub. Document the Assistant here.
-</Note>

--- a/agent-wiki/automate/agents_and_actions.mdx
+++ b/agent-wiki/automate/agents_and_actions.mdx
@@ -1,0 +1,9 @@
+---
+title: "Agents & Actions"
+description: "Connect agents to read and update your wiki"
+icon: "robot"
+---
+
+<Note>
+  This page is a stub. Document Agents & Actions here.
+</Note>

--- a/agent-wiki/automate/auto_organize.mdx
+++ b/agent-wiki/automate/auto_organize.mdx
@@ -1,0 +1,9 @@
+---
+title: "Auto Organize"
+description: "Let the wiki propose and apply cleanups"
+icon: "wand-magic-sparkles"
+---
+
+<Note>
+  This page is a stub. Document Auto Organize here.
+</Note>

--- a/agent-wiki/automate/chats.mdx
+++ b/agent-wiki/automate/chats.mdx
@@ -1,0 +1,9 @@
+---
+title: "Chats"
+description: "Ask questions and make edits in conversation"
+icon: "message"
+---
+
+<Note>
+  This page is a stub. Document Chats here.
+</Note>

--- a/agent-wiki/automate/mcp.mdx
+++ b/agent-wiki/automate/mcp.mdx
@@ -1,0 +1,194 @@
+---
+title: "Connect an Agent (MCP)"
+description: "Connect Claude Code, Cursor, Codex, or Onyx to your wiki over MCP"
+icon: "plug"
+---
+
+Agent Wiki exposes itself as a [Model Context Protocol](https://modelcontextprotocol.io) server,
+so any MCP-capable agent can search, read, edit, and comment on wiki pages the same way you do.
+The wiki becomes shared memory for your agents: they load context from it before working,
+and write back what they learn.
+
+The agent acts **under your account, with your permissions**. It can reach exactly the pages you can reach.
+
+## Get your credentials
+
+Open **Agents & Actions** in the left sidebar.
+
+<Steps>
+  <Step title="Copy the MCP server URL">
+    The endpoint is your wiki's origin followed by `/api/mcp` — for example `https://wiki.example.com/api/mcp`.
+  </Step>
+
+  <Step title="Generate an API key">
+    Click **Generate API key** and name it for the device or agent that will use it (`claude-code-laptop`).
+    Copy the `mcp_…` value immediately.
+
+    <Warning>
+      The key is shown **once**. If you lose it, generate another and revoke the old one from the same page.
+    </Warning>
+  </Step>
+</Steps>
+
+## Connect your agent
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add --transport http agent-wiki \
+      https://wiki.example.com/api/mcp \
+      --header "Authorization: Bearer mcp_REPLACE_ME"
+    ```
+
+    <Warning>
+      **Argument order matters.** The URL must come directly after the name, and `--header` must come last.
+      `--header` is variadic, so a URL placed after it is swallowed as another header value and you get `error:
+      missing required argument 'commandOrUrl'`.
+    </Warning>
+
+    Add `-s user` to make the wiki available in every project.
+    Without it the server is registered only for the directory you ran the command in,
+    and `claude mcp get` from anywhere else reports "No MCP server found".
+
+    Confirm the connection with `claude mcp get agent-wiki` (or `/mcp` inside a session) — it should report `Status:
+    ✓ Connected`.
+
+    To share the connection with a repository instead, check in a `.mcp.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "agent-wiki": {
+          "type": "http",
+          "url": "https://wiki.example.com/api/mcp"
+        }
+      }
+    }
+    ```
+
+    Restart Claude Code or run `/mcp` after changing `.mcp.json`.
+  </Tab>
+
+  <Tab title="Cursor">
+    Add the server to `~/.cursor/mcp.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "agent-wiki": {
+          "url": "https://wiki.example.com/api/mcp",
+          "headers": { "Authorization": "Bearer mcp_REPLACE_ME" }
+        }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Codex CLI">
+    Add the server to `~/.codex/config.toml`:
+
+    ```toml
+    [mcp_servers.agent-wiki]
+    url = "https://wiki.example.com/api/mcp"
+    headers = { Authorization = "Bearer mcp_REPLACE_ME" }
+    ```
+  </Tab>
+
+  <Tab title="Onyx">
+    Using an account with `manage:actions`,
+    go to **Settings → MCP Actions → Add MCP Server** and enter the wiki's MCP URL.
+
+    Choose **API Key** authentication with either a **Shared Key** configured as `Authorization: Bearer mcp_…`,
+    or an **Individual Key** so each user supplies their own credential from the chat Actions popover.
+    Individual keys keep per-user wiki permissions intact, which is usually what you want.
+
+    Onyx then lists the server's tools and lets you expose the ones you choose to your Agents.
+  </Tab>
+
+  <Tab title="Claude Desktop">
+    Claude Desktop is **not a validated setup path**.
+    `claude_desktop_config.json` accepts only local STDIO server entries (`command`, `args`, `env`)
+    — not remote HTTP entries with `url` and `headers`.
+
+    If you want to try it anyway,
+    bridge through `mcp-remote` and keep the bearer value in `env` to avoid header escaping problems on macOS:
+
+    ```json
+    {
+      "mcpServers": {
+        "agent-wiki": {
+          "command": "npx",
+          "args": [
+            "mcp-remote",
+            "https://wiki.example.com/api/mcp",
+            "--header",
+            "Authorization:${AGENT_WIKI_AUTH}"
+          ],
+          "env": { "AGENT_WIKI_AUTH": "Bearer mcp_REPLACE_ME" }
+        }
+      }
+    }
+    ```
+
+    Fully quit and relaunch Claude Desktop afterwards — closing the window is not enough,
+    since MCP configuration is only re-read on a full restart.
+
+    Claude.ai web **Custom Connectors** and Claude Desktop's built-in **Connectors** UI support only OAuth and expose no
+    static bearer-token field, so neither works with Agent Wiki today.
+  </Tab>
+</Tabs>
+
+## What the agent can do
+
+Once connected, the agent gets these tools:
+
+| Tool | What it does |
+| --- | --- |
+| `search_wiki` | Keyword search across pages you can read |
+| `ask_nl_question` | Ask a question in plain English and get an answer with sources |
+| `read_doc` | Read a page at the current version or any past commit |
+| `list_history` | Per-page commit log |
+| `search_comments` | Search discussion threads, with deep links |
+| `write_doc` | Create a page or replace its body |
+| `edit_doc` / `multi_edit` | Find-and-replace edits, single or batched atomically |
+| `apply_patch` | Apply a unified diff |
+| `update_doc_nl` | Hand the page to the wiki's own updater agent with an instruction |
+| `move_path` | Rename or move a page or folder |
+| `create_directory` | Create a folder |
+| `delete_doc` | Move a page to Trash, restorable for 30 days |
+| `add_comment` / `reply_comment` / `resolve_comment` | Take part in discussion threads |
+| `list_templates` | List the starter templates available for new pages |
+| `set_update_policy` | Set how the wiki may auto-update a page or folder |
+
+Edits are ordinary git commits attributed to you, so anything an agent does is visible in page history and reversible.
+
+## Permissions and safety
+
+- **The token inherits your permissions in full.** A key minted by an admin is an admin key. Generate keys from the
+  account whose access you actually want the agent to have.
+- **Deletes are recoverable.** `delete_doc` moves a page to Trash with a 30-day restore window, and it works on pages
+  only — folder deletion stays a human action.
+- **Keys are revocable.** Revoke from **Agents & Actions** at any time.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="missing required argument 'commandOrUrl'">
+    The URL came after `--header` in `claude mcp add`. Put the URL directly after the server name and `--header` last.
+  </Accordion>
+
+  <Accordion title="No MCP server found from another directory">
+    The server was added at local scope. Re-add it with `-s user` to make it available everywhere.
+  </Accordion>
+
+  <Accordion title="The connection drops or never establishes in local development">
+    Point the client at the backend directly (`http://localhost:8080/api/mcp`) rather than the Next.js dev server.
+    The dev server's `/api/:path*` rewrite buffers responses and breaks the transport when the client sends `Accept:
+    text/event-stream`.
+  </Accordion>
+
+  <Accordion title="Links in tool results point at the wrong host">
+    Tool results build absolute URLs from `PUBLIC_BASE_URL`. If it is wrong,
+    the links are wrong — see [Configuration](/agent-wiki/deployment/configuration).
+  </Accordion>
+</AccordionGroup>

--- a/agent-wiki/automate/mcp.mdx
+++ b/agent-wiki/automate/mcp.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Connect an Agent (MCP)"
-description: "Connect Claude Code, Cursor, Codex, or Onyx to your wiki over MCP"
+description: "Connect Claude Code, Cursor, Codex, or Onyx Craft to your wiki over MCP"
 icon: "plug"
 ---
 
@@ -94,15 +94,43 @@ Open **Agents & Actions** in the left sidebar.
     ```
   </Tab>
 
-  <Tab title="Onyx">
-    Using an account with `manage:actions`,
-    go to **Settings → MCP Actions → Add MCP Server** and enter the wiki's MCP URL.
+  <Tab title="Onyx Craft">
+    In Onyx, the agent that works with MCP servers is **Craft**. Connecting takes two parts:
+    an admin registers the wiki once for the organization, then each person connects their own key.
 
-    Choose **API Key** authentication with either a **Shared Key** configured as `Authorization: Bearer mcp_…`,
-    or an **Individual Key** so each user supplies their own credential from the chat Actions popover.
-    Individual keys keep per-user wiki permissions intact, which is usually what you want.
+    **Admin — register the wiki (once)**
 
-    Onyx then lists the server's tools and lets you expose the ones you choose to your Agents.
+    <Steps>
+      <Step title="Add the MCP server">
+        In the Admin Panel, open **MCP Actions → Add MCP Server** and enter your wiki's MCP URL.
+        See [MCP Actions](/admins/actions/mcp) for the full field reference.
+      </Step>
+
+      <Step title="Choose API Key authentication">
+        Pick **Individual Key** so each person supplies their own `mcp_…` key — that keeps each user's agent inside
+        their own wiki permissions. A **Shared Key** gives everyone the access of whichever account minted it.
+      </Step>
+
+      <Step title="Select the tools to expose">
+        Onyx lists the wiki's tools and lets you choose which are available to agents across the organization.
+      </Step>
+
+      <Step title="Turn it on for Craft">
+        Go to **Admin Panel → Craft → Apps** and enable the wiki.
+        The card should read "Available to the Craft agent — tool calls follow their approval policies".
+        Until this is on, Craft cannot see the wiki at all.
+      </Step>
+    </Steps>
+
+    **Each user — connect (once)**
+
+    Open **Craft → Apps**, find the wiki, click **Connect**, and paste your API key from **Agents & Actions**.
+    The credential is shared across surfaces: connect in Craft and you are connected in chat too, and vice versa.
+
+    <Note>
+      Craft tool calls are gated per tool at the sandbox boundary. By default the agent asks before each call;
+      admins can set a tool to always-allow or deny from the MCP admin page.
+    </Note>
   </Tab>
 
   <Tab title="Claude Desktop">

--- a/agent-wiki/automate/triggers.mdx
+++ b/agent-wiki/automate/triggers.mdx
@@ -1,0 +1,9 @@
+---
+title: "Triggers"
+description: "Watch pages for changes or run on a schedule"
+icon: "bolt"
+---
+
+<Note>
+  This page is a stub. Document triggers here.
+</Note>

--- a/agent-wiki/deployment/configuration.mdx
+++ b/agent-wiki/deployment/configuration.mdx
@@ -1,0 +1,9 @@
+---
+title: "Configuration"
+description: "Environment variables and runtime settings"
+icon: "wrench"
+---
+
+<Note>
+  This page is a stub. Document configuration here.
+</Note>

--- a/agent-wiki/deployment/docker_compose.mdx
+++ b/agent-wiki/deployment/docker_compose.mdx
@@ -11,18 +11,36 @@ and OpenSearch for the data plane, then the backend, two worker processes, the f
 
 - Docker with Compose v2 (`docker compose version`)
 - `git` and `openssl`
-- **8 GB of RAM recommended**, 4 GB minimum
+- **4 GB of RAM** to run the stack, **8 GB** if you build the images on the same host
 
-Memory is the constraint worth checking before you start. The app containers are capped at 1 GB (backend),
-1 GB per worker group, and 512 MB (frontend);
-OpenSearch runs with a 512 MB JVM heap and wants roughly double that in practice.
-Steady-state usage sits well below the sum of those ceilings,
-but the frontend's production build is the peak — if the first build dies without an obvious error,
-it ran out of memory.
+### Memory footprint
+
+Measured on an idle stack, all eight containers running:
+
+| Container | Memory |
+| --- | --- |
+| `opensearch` | 1.32 GB |
+| `backend` | 490 MB |
+| `worker-heavy` | 196 MB |
+| `worker-light` | 197 MB |
+| `postgres` | 186 MB |
+| `frontend` | 51 MB |
+| `redis` | 13 MB |
+| `nginx` | 12 MB |
+| **Total** | **~2.4 GB** |
+
+Agent Wiki's own processes account for under 1 GB of that.
+**OpenSearch is the majority of the footprint** — it runs with a 512 MB JVM heap,
+and the rest is JVM overhead and file cache. It is a required dependency, not an optional one.
+
+Expect the app processes to grow above these idle figures under real use:
+the backend and workers do LLM calls and git operations, and the workers add roughly 15 MB per active thread.
 
 <Note>
-  On Docker Desktop, the limit that matters is the VM's memory allocation, not the host's.
-  Raise it under **Settings → Resources** if the default is below 8 GB.
+  The peak is the **frontend production build**, not the running stack — that is what the 8 GB figure covers.
+  If the first build dies without an obvious error, it ran out of memory.
+  On Docker Desktop the binding limit is the VM's memory allocation rather than host RAM;
+  raise it under **Settings → Resources**.
 </Note>
 
 ## Install

--- a/agent-wiki/deployment/docker_compose.mdx
+++ b/agent-wiki/deployment/docker_compose.mdx
@@ -11,7 +11,7 @@ and OpenSearch for the data plane, then the backend, two worker processes, the f
 
 - Docker with Compose v2 (`docker compose version`)
 - `git` and `openssl`
-- **4 GB of RAM** to run the stack, **8 GB** if you build the images on the same host
+- **8 GB of RAM** — the images are built on your machine during install
 
 ## Install
 

--- a/agent-wiki/deployment/docker_compose.mdx
+++ b/agent-wiki/deployment/docker_compose.mdx
@@ -13,36 +13,6 @@ and OpenSearch for the data plane, then the backend, two worker processes, the f
 - `git` and `openssl`
 - **4 GB of RAM** to run the stack, **8 GB** if you build the images on the same host
 
-### Memory footprint
-
-Measured on an idle stack, all eight containers running:
-
-| Container | Memory |
-| --- | --- |
-| `opensearch` | 1.32 GB |
-| `backend` | 490 MB |
-| `worker-heavy` | 196 MB |
-| `worker-light` | 197 MB |
-| `postgres` | 186 MB |
-| `frontend` | 51 MB |
-| `redis` | 13 MB |
-| `nginx` | 12 MB |
-| **Total** | **~2.4 GB** |
-
-Agent Wiki's own processes account for under 1 GB of that.
-**OpenSearch is the majority of the footprint** — it runs with a 512 MB JVM heap,
-and the rest is JVM overhead and file cache. It is a required dependency, not an optional one.
-
-Expect the app processes to grow above these idle figures under real use:
-the backend and workers do LLM calls and git operations, and the workers add roughly 15 MB per active thread.
-
-<Note>
-  The peak is the **frontend production build**, not the running stack — that is what the 8 GB figure covers.
-  If the first build dies without an obvious error, it ran out of memory.
-  On Docker Desktop the binding limit is the VM's memory allocation rather than host RAM;
-  raise it under **Settings → Resources**.
-</Note>
-
 ## Install
 
 The installer clones the repository, generates a `.env`, builds the images, and starts the stack:
@@ -159,6 +129,12 @@ git pull && docker compose --profile app up -d --build
 
   <Accordion title="Only Postgres and Redis started">
     The `--profile app` flag was omitted. Without it Compose starts the data plane only.
+  </Accordion>
+
+  <Accordion title="The build stops partway with no clear error">
+    It most likely ran out of memory. On Docker Desktop,
+    raise the VM's memory allocation under **Settings → Resources** — the host having enough RAM is not enough on its
+    own.
   </Accordion>
 
   <Accordion title="Links point at localhost from another machine">

--- a/agent-wiki/deployment/docker_compose.mdx
+++ b/agent-wiki/deployment/docker_compose.mdx
@@ -4,14 +4,26 @@ description: "Run Agent Wiki on a single host with Docker Compose"
 icon: "docker"
 ---
 
-Docker Compose is the fastest way to run Agent Wiki. It brings up Postgres, the backend, the workers, the frontend,
-and nginx on one host.
+Docker Compose is the fastest way to run Agent Wiki. It brings up the whole stack on one host: Postgres, Redis,
+and OpenSearch for the data plane, then the backend, two worker processes, the frontend, and nginx for the app plane.
 
 ## Requirements
 
 - Docker with Compose v2 (`docker compose version`)
 - `git` and `openssl`
-- ~4 GB of free memory for the first build
+- **8 GB of RAM recommended**, 4 GB minimum
+
+Memory is the constraint worth checking before you start. The app containers are capped at 1 GB (backend),
+1 GB per worker group, and 512 MB (frontend);
+OpenSearch runs with a 512 MB JVM heap and wants roughly double that in practice.
+Steady-state usage sits well below the sum of those ceilings,
+but the frontend's production build is the peak — if the first build dies without an obvious error,
+it ran out of memory.
+
+<Note>
+  On Docker Desktop, the limit that matters is the VM's memory allocation, not the host's.
+  Raise it under **Settings → Resources** if the default is below 8 GB.
+</Note>
 
 ## Install
 

--- a/agent-wiki/deployment/docker_compose.mdx
+++ b/agent-wiki/deployment/docker_compose.mdx
@@ -1,0 +1,139 @@
+---
+title: "Docker Compose"
+description: "Run Agent Wiki on a single host with Docker Compose"
+icon: "docker"
+---
+
+Docker Compose is the fastest way to run Agent Wiki. It brings up Postgres, the backend, the workers, the frontend,
+and nginx on one host.
+
+## Requirements
+
+- Docker with Compose v2 (`docker compose version`)
+- `git` and `openssl`
+- ~4 GB of free memory for the first build
+
+## Install
+
+The installer clones the repository, generates a `.env`, builds the images, and starts the stack:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/onyx-dot-app/agent-wiki/main/install.sh | bash
+```
+
+The first build takes a few minutes. When it finishes, open `http://localhost:8090`.
+
+<Note>
+  **The first account you create becomes the admin.** Sign up as soon as the stack is running,
+  before anyone else can claim it.
+</Note>
+
+### Install options
+
+The installer reads a few environment variables:
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `AGENT_WIKI_PORT` | `8090` | Host port nginx publishes |
+| `AGENT_WIKI_DIR` | `./agent-wiki` | Where the repository is cloned |
+| `AGENT_WIKI_REF` | `main` | Branch or tag to check out |
+
+```bash
+AGENT_WIKI_PORT=9000 bash -c "$(curl -fsSL https://raw.githubusercontent.com/onyx-dot-app/agent-wiki/main/install.sh)"
+```
+
+## Install manually
+
+If you would rather not pipe a script to your shell, do the same steps by hand:
+
+<Steps>
+  <Step title="Clone the repository">
+    ```bash
+    git clone https://github.com/onyx-dot-app/agent-wiki.git
+    cd agent-wiki
+    ```
+  </Step>
+
+  <Step title="Create your .env">
+    Copy `.env.example` to `.env`, then set a real secret key and the URL the stack will be reached on:
+
+    ```bash
+    cp .env.example .env
+    echo "SECRET_KEY=$(openssl rand -hex 32)" >> .env
+    echo "PUBLIC_BASE_URL=http://localhost:8090" >> .env
+    echo "AGENT_WIKI_PORT=8090" >> .env
+    ```
+  </Step>
+
+  <Step title="Start the stack">
+    The application containers sit behind the `app` Compose profile. Without it, only the data plane starts:
+
+    ```bash
+    docker compose --profile app up -d --build
+    ```
+  </Step>
+
+  <Step title="Claim the admin account">
+    Open `http://localhost:8090` and sign up. The first account becomes the admin.
+  </Step>
+</Steps>
+
+## Required settings
+
+Two values must be right or the backend refuses to boot:
+
+- **`SECRET_KEY`** — any non-empty, non-default value. The backend and workers refuse to start with the built-in
+  development secret, so production deployments cannot accidentally run with a known key.
+- **`PUBLIC_BASE_URL`** — the browser-facing origin the stack is reached on, with no trailing slash. It is never
+  inferred from request headers, because a spoofed `Host` header would then control the URLs the app hands out.
+  Agent Wiki uses it to build the MCP endpoint, launcher deep links, and links in outbound email.
+
+If you put the stack behind a domain or a reverse proxy,
+set `PUBLIC_BASE_URL` to the external URL — `https://wiki.example.com`, not `http://localhost:8090`.
+
+## After installing
+
+<Steps>
+  <Step title="Configure a language model">
+    Go to **Admin → Language Models** and add a provider. Agents, triggers,
+    and Auto Organize all stay idle until a model is configured.
+  </Step>
+
+  <Step title="Connect an agent">
+    Generate an API key under **Agents & Actions** and point your coding agent at the wiki.
+    See [Connect an Agent (MCP)](/agent-wiki/automate/mcp).
+  </Step>
+</Steps>
+
+## Operating the stack
+
+```bash
+# follow logs
+docker compose --profile app logs -f
+
+# stop
+docker compose --profile app down
+
+# upgrade to the latest code
+git pull && docker compose --profile app up -d --build
+```
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="The app never responds on the published port">
+    Check the logs with `docker compose --profile app logs -f`.
+    The most common cause is a missing `PUBLIC_BASE_URL` or a `SECRET_KEY` still set to the default value — the backend
+    exits at boot in both cases.
+  </Accordion>
+
+  <Accordion title="Only Postgres and Redis started">
+    The `--profile app` flag was omitted. Without it Compose starts the data plane only.
+  </Accordion>
+
+  <Accordion title="Links point at localhost from another machine">
+    `PUBLIC_BASE_URL` is still set to `http://localhost:<port>`. Set it to the external URL and recreate the containers.
+  </Accordion>
+</AccordionGroup>
+
+For a multi-node deployment, see [Kubernetes](/agent-wiki/deployment/kubernetes).

--- a/agent-wiki/deployment/docker_compose.mdx
+++ b/agent-wiki/deployment/docker_compose.mdx
@@ -11,7 +11,7 @@ and OpenSearch for the data plane, then the backend, two worker processes, the f
 
 - Docker with Compose v2 (`docker compose version`)
 - `git` and `openssl`
-- **8 GB of RAM** — the images are built on your machine during install
+- **4 GB of RAM** — the running stack uses about 2.5 GB
 
 ## Install
 
@@ -131,8 +131,8 @@ git pull && docker compose --profile app up -d --build
     The `--profile app` flag was omitted. Without it Compose starts the data plane only.
   </Accordion>
 
-  <Accordion title="The build stops partway with no clear error">
-    It most likely ran out of memory. On Docker Desktop,
+  <Accordion title="The first install stops partway with no clear error">
+    Building the images needs more headroom than running them. On Docker Desktop,
     raise the VM's memory allocation under **Settings → Resources** — the host having enough RAM is not enough on its
     own.
   </Accordion>

--- a/agent-wiki/deployment/kubernetes.mdx
+++ b/agent-wiki/deployment/kubernetes.mdx
@@ -1,0 +1,9 @@
+---
+title: "Kubernetes"
+description: "Deploy Agent Wiki with the Helm chart"
+icon: "cubes"
+---
+
+<Note>
+  This page is a stub. Document the Helm deployment here.
+</Note>

--- a/agent-wiki/editor.mdx
+++ b/agent-wiki/editor.mdx
@@ -1,9 +1,0 @@
----
-title: "Editor"
-description: "Co-editing documents with humans and agents"
-icon: "pen-to-square"
----
-
-<Note>
-  This page is a stub. Document the Editor here.
-</Note>

--- a/agent-wiki/home.mdx
+++ b/agent-wiki/home.mdx
@@ -1,9 +1,0 @@
----
-title: "Home"
-description: "The Agent Wiki home view"
-icon: "house"
----
-
-<Note>
-  This page is a stub. Document the Home view here.
-</Note>

--- a/agent-wiki/mcp.mdx
+++ b/agent-wiki/mcp.mdx
@@ -1,9 +1,0 @@
----
-title: "MCP"
-description: "The Agent Wiki MCP server"
-icon: "plug"
----
-
-<Note>
-  This page is a stub. Document the MCP server here.
-</Note>

--- a/agent-wiki/settings.mdx
+++ b/agent-wiki/settings.mdx
@@ -1,9 +1,0 @@
----
-title: "Settings"
-description: "Configuring your Agent Wiki"
-icon: "gear"
----
-
-<Note>
-  This page is a stub. Document Settings here.
-</Note>

--- a/agent-wiki/using/account_settings.mdx
+++ b/agent-wiki/using/account_settings.mdx
@@ -1,0 +1,9 @@
+---
+title: "Account Settings"
+description: "Theme, timezone, and personal preferences"
+icon: "gear"
+---
+
+<Note>
+  This page is a stub. Document account settings here.
+</Note>

--- a/agent-wiki/using/editor.mdx
+++ b/agent-wiki/using/editor.mdx
@@ -1,0 +1,9 @@
+---
+title: "Editor"
+description: "Co-editing pages with humans and agents"
+icon: "pen-to-square"
+---
+
+<Note>
+  This page is a stub. Document the editor here.
+</Note>

--- a/agent-wiki/using/trash.mdx
+++ b/agent-wiki/using/trash.mdx
@@ -1,0 +1,9 @@
+---
+title: "Trash"
+description: "Restoring deleted pages"
+icon: "trash"
+---
+
+<Note>
+  This page is a stub. Document Trash here.
+</Note>

--- a/agent-wiki/using/update_policies.mdx
+++ b/agent-wiki/using/update_policies.mdx
@@ -1,0 +1,9 @@
+---
+title: "Update Policies"
+description: "Controlling how agents update a page or folder"
+icon: "sliders"
+---
+
+<Note>
+  This page is a stub. Document update policies here.
+</Note>

--- a/agent-wiki/using/wiki.mdx
+++ b/agent-wiki/using/wiki.mdx
@@ -1,0 +1,9 @@
+---
+title: "The Wiki"
+description: "Browsing, organizing, and searching pages"
+icon: "book"
+---
+
+<Note>
+  This page is a stub. Document the wiki view here.
+</Note>

--- a/agent-wiki/welcome.mdx
+++ b/agent-wiki/welcome.mdx
@@ -4,6 +4,13 @@ description: "A shared collaboration space for humans and agents"
 icon: "house"
 ---
 
+<Warning>
+  **These docs are under active development.** Agent Wiki is still being built,
+  and this documentation is being written alongside it. Some pages are placeholders,
+  and details may change between releases. If something here does not match what you see in the product,
+  trust the product.
+</Warning>
+
 ## What is Agent Wiki?
 
 Agent Wiki is a shared collaboration space for humans and AI agents — a living source of truth for status, knowledge,

--- a/agent-wiki/welcome.mdx
+++ b/agent-wiki/welcome.mdx
@@ -23,7 +23,15 @@ editable by both people and agents.
     Set up your first wiki space and invite agents in minutes.
   </Card>
 
-  <Card title="The Editor" icon="pen-to-square" href="/agent-wiki/editor">
+  <Card title="Run Agent Wiki" icon="docker" href="/agent-wiki/deployment/docker_compose">
+    Bring up the stack on your own host with Docker Compose.
+  </Card>
+
+  <Card title="Connect an Agent" icon="plug" href="/agent-wiki/automate/mcp">
+    Point Claude Code, Cursor, Codex, or Onyx at your wiki over MCP.
+  </Card>
+
+  <Card title="The Editor" icon="pen-to-square" href="/agent-wiki/using/editor">
     Learn how humans and agents co-edit documents.
   </Card>
 </Columns>

--- a/agent-wiki/workflows.mdx
+++ b/agent-wiki/workflows.mdx
@@ -1,9 +1,0 @@
----
-title: "Workflows"
-description: "Automating work in Agent Wiki"
-icon: "diagram-project"
----
-
-<Note>
-  This page is a stub. Document Workflows here.
-</Note>

--- a/docs.json
+++ b/docs.json
@@ -607,24 +607,44 @@
             "pages": ["agent-wiki/welcome", "agent-wiki/quickstart"]
           },
           {
-            "group": "Core",
+            "group": "Using Agent Wiki",
             "pages": [
-              "agent-wiki/home",
-              "agent-wiki/editor",
-              "agent-wiki/analytics"
+              "agent-wiki/using/wiki",
+              "agent-wiki/using/editor",
+              "agent-wiki/using/update_policies",
+              "agent-wiki/using/trash",
+              "agent-wiki/using/account_settings"
             ]
           },
           {
             "group": "Automate",
             "pages": [
-              "agent-wiki/workflows",
-              "agent-wiki/agent",
-              "agent-wiki/assistant"
+              "agent-wiki/automate/mcp",
+              "agent-wiki/automate/agents_and_actions",
+              "agent-wiki/automate/triggers",
+              "agent-wiki/automate/chats",
+              "agent-wiki/automate/auto_organize"
+            ]
+          },
+          {
+            "group": "Deployment",
+            "pages": [
+              "agent-wiki/deployment/docker_compose",
+              "agent-wiki/deployment/kubernetes",
+              "agent-wiki/deployment/configuration"
             ]
           },
           {
             "group": "Admin",
-            "pages": ["agent-wiki/mcp", "agent-wiki/settings"]
+            "pages": [
+              "agent-wiki/admin/overview",
+              "agent-wiki/admin/language_models",
+              "agent-wiki/admin/templates",
+              "agent-wiki/admin/users_and_groups",
+              "agent-wiki/admin/onyx_integration",
+              "agent-wiki/admin/notifications",
+              "agent-wiki/admin/status"
+            ]
           }
         ]
       }


### PR DESCRIPTION
## Description

The Agent Wiki stub set from #426 didn't match the product's actual navigation, so the page names would have taught readers vocabulary the UI doesn't use. Renamed to the product's own terms and regrouped, while the section is still hidden and nothing links in — free to do now, a redirect later.

| Was | Now | Why |
| --- | --- | --- |
| `home` | `using/wiki` | matches `/app/wiki` |
| `workflows` | `automate/triggers` | the product says "Triggers" |
| `agent` | `automate/agents_and_actions` | the product says "Agents & Actions" |
| `assistant` | `automate/chats` | the product says "Chats" |
| `settings` | `using/account_settings` | `/app/settings` is personal prefs, not the admin console |
| `analytics` | *deleted* | no analytics surface exists — zero hits in the frontend |

Added stubs for surfaces that had no page at all: update policies, Trash, Auto Organize, deployment (Compose / Kubernetes / configuration), and the seven admin console pages. 22 pages total; the tab stays `"hidden": true`.

Two pages are written in full, from sources verified against the Agent Wiki and Onyx source rather than their design docs:

**`automate/mcp` — Connect an Agent.** The wiki's internal MCP onboarding guide, genericized for self-hosted readers. Endpoint is `/api/mcp`, confirmed against the router prefix in `main.py`; the design page's `/api/v1/mcp` is stale and would have shipped a broken URL. Tool table checked against `MCP_ALLOWED_TOOLS`. The Onyx tab covers the real three-surface Craft flow — register under MCP Actions, enable on **Admin → Craft → Apps** (the step that is easy to miss; without it Craft cannot see the wiki), then each user connects their own key — cross-linked to the existing `/admins/actions/mcp` page rather than restating it.

**`deployment/docker_compose`.** From `install.sh` and the repo README: the one-line installer, the manual path, and the two settings that block boot (`SECRET_KEY`, `PUBLIC_BASE_URL`). The memory requirement is 4 GB, measured off a running stack (~2.5 GB across all eight containers) rather than inferred from Helm limits.

Also adds a development-in-progress banner to `welcome`, since most pages are still placeholders.

## How Has This Been Tested?

Ran `mintlify dev` locally and checked the rendered output:

- All 22 `/agent-wiki/*` URLs return 200; the 8 old paths return 404.
- The tab bar on a normal page still renders Overview, Deployment, Admins, Developers, Security, Changelog — no Agent Wiki entry.
- Nav entries and files cross-checked both directions: no nav entry without a file, no file outside the nav.
- `scripts/format_docs.py --write` applied; `mintlify broken-links` reports none.

## Related

onyx-dot-app/agent-wiki#545 makes the Compose install pull published images instead of building from source. When that lands and a `v*` tag publishes all four images, this page's install section flips to the Onyx "pull images from Docker Hub" wording and the build-headroom troubleshooting entry can be deleted.

## Still stubs

In rough order of how much source material exists: Triggers (two wiki guides port over directly), Quickstart, Auto Organize, Kubernetes/configuration, then the editor / wiki view / chats / admin pages — those have no user-facing source and likely need screenshots before launch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check