### PR TITLE
docs: document CHAT_SESSION_NAMING_MODEL(_PROVIDER) env vars

### DIFF
--- a/deployment/configuration/configuration.mdx
+++ b/deployment/configuration/configuration.mdx
@@ -269,6 +269,11 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
 
     `DISABLE_GENERATIVE_AI`: Disable generative AI features.
 
+    `CHAT_SESSION_NAMING_MODEL_PROVIDER` / `CHAT_SESSION_NAMING_MODEL`: Pin chat session auto-naming to a
+    dedicated model (provider name as configured in the admin panel + model name; both must be set).
+    When unset, naming uses the session's model. Useful when the session model is a local single-stream
+    model that concurrent naming calls would block.
+
     `DISABLE_USER_KNOWLEDGE`: Controls whether users can use the My Documents feature with assistants.
 
     `ONYX_QUERY_HISTORY_TYPE`: Controls query history reports (show user emails, anonymous, no queries)


### PR DESCRIPTION
Documents the two env vars added in onyx-dot-app/onyx#13557: `CHAT_SESSION_NAMING_MODEL_PROVIDER` + `CHAT_SESSION_NAMING_MODEL` pin chat session auto-naming to a dedicated model (both must be set); unset, naming uses the session's model. Useful for single-stream local-model deployments where concurrent naming calls would block chat generation.

Should merge alongside (or after) onyx-dot-app/onyx#13557.