### PR TITLE
docs(deployment): document onyx-cli deploy lifecycle commands

### DIFF
--- a/deployment/local/craft.mdx
+++ b/deployment/local/craft.mdx
@@ -26,7 +26,7 @@ Self-hosted deployments can run these sandboxes in Kubernetes or Docker.
 | --- | --- | --- |
 | Sandbox runtime | One pod per active user | One container per active user |
 | Recommended for | Production and multi-node deployments | Single-host self-hosted deployments |
-| Provisioning | Onyx Helm chart | `install.sh --include-craft` |
+| Provisioning | Onyx Helm chart | `onyx-cli deploy install --include-craft` |
 | Host access | Kubernetes API through scoped RBAC | Docker socket access on the host |
 
 ## Requirements

--- a/deployment/local/craft_docker_compose.mdx
+++ b/deployment/local/craft_docker_compose.mdx
@@ -39,7 +39,7 @@ creates the sandbox bridge network and proxy CA volume, and starts the deploymen
 
 <Note>
   The examples below use the CLI's default deployment directory.
-  For a deployment created by the legacy `install.sh` script,
+  For a deployment created by an older version of the `install.sh` script,
   replace `~/.config/onyx` with your `onyx_data` directory (e.g. `onyx_data/deployment/.env`).
 </Note>
 

--- a/deployment/local/craft_docker_compose.mdx
+++ b/deployment/local/craft_docker_compose.mdx
@@ -28,17 +28,22 @@ Craft does not run with the Onyx Lite Compose overlay.
 
 ## New deployment
 
-Run the installer with the Craft overlay:
+Run the [Onyx CLI](/deployment/local/onyx_cli) installer with the Craft overlay:
 
 ```bash
-cd onyx/deployment/docker_compose
-./install.sh --include-craft
+onyx-cli deploy install --include-craft
 ```
 
 The installer downloads `docker-compose.craft.yml`, enables Craft, selects the Docker sandbox backend,
 creates the sandbox bridge network and proxy CA volume, and starts the deployment.
 
-Open `onyx_data/deployment/.env` and set the Onyx URL:
+<Note>
+  The examples below use the CLI's default deployment directory.
+  For a deployment created by the legacy `install.sh` script,
+  replace `~/.config/onyx` with your `onyx_data` directory (e.g. `onyx_data/deployment/.env`).
+</Note>
+
+Open `~/.config/onyx/deployment/.env` and set the Onyx URL:
 
 ```dotenv
 SANDBOX_API_SERVER_URL=https://onyx.example.com
@@ -47,7 +52,7 @@ SANDBOX_API_SERVER_URL=https://onyx.example.com
 Then recreate the affected services with both Compose files:
 
 ```bash
-cd onyx_data/deployment
+cd ~/.config/onyx/deployment
 docker compose \
   -f docker-compose.yml \
   -f docker-compose.craft.yml \
@@ -56,11 +61,10 @@ docker compose \
 
 ## Existing deployment
 
-Set `SANDBOX_API_SERVER_URL` in the existing `onyx_data/deployment/.env`, then rerun the installer:
+Set `SANDBOX_API_SERVER_URL` in the existing deployment's `.env`, then rerun the installer:
 
 ```bash
-cd onyx/deployment/docker_compose
-./install.sh --include-craft
+onyx-cli deploy install --include-craft
 ```
 
 The installer adds the Craft overlay and updates the existing `.env` with:
@@ -111,7 +115,7 @@ Normal deployments should not set `SANDBOX_CONTAINER_IMAGE` separately.
 Confirm the core services and proxy are running:
 
 ```bash
-cd onyx_data/deployment
+cd ~/.config/onyx/deployment
 docker compose \
   -f docker-compose.yml \
   -f docker-compose.craft.yml \
@@ -150,7 +154,7 @@ See [Craft Architecture](/security/architecture/craft) for the complete trust an
   </Accordion>
 
   <Accordion title="Sandbox provisioning reports that SANDBOX_API_SERVER_URL is missing">
-    Set the value in `onyx_data/deployment/.env` and recreate the API server, background worker,
+    Set the value in the deployment directory's `.env` and recreate the API server, background worker,
     and sandbox proxy with the Craft overlay.
   </Accordion>
 
@@ -166,7 +170,8 @@ See [Craft Architecture](/security/architecture/craft) for the complete trust an
   </Accordion>
 
   <Accordion title="The sandbox network or CA volume is missing">
-    Rerun `install.sh --include-craft`. If automatic creation fails, create the resources and restart the deployment:
+    Rerun `onyx-cli deploy install --include-craft`. If automatic creation fails,
+    create the resources and restart the deployment:
 
     ```bash
     docker network create onyx_craft_sandbox

--- a/deployment/local/docker.mdx
+++ b/deployment/local/docker.mdx
@@ -12,7 +12,9 @@ import DeploymentNextSteps from "/snippets/deployment-next-steps.mdx"
 
 <Note>
   This guide covers managing the compose files manually. For a guided install with managed upgrades,
-  use the [installation scripts](/deployment/getting_started/quickstart) or the [Onyx CLI](/deployment/local/onyx_cli).
+  use the [Onyx CLI](/deployment/local/onyx_cli)
+  instead — it can also [adopt an existing manual setup](/deployment/local/onyx_cli#from-a-manual-docker-compose-setup)
+  later.
 </Note>
 
 ## Guide

--- a/deployment/local/docker.mdx
+++ b/deployment/local/docker.mdx
@@ -10,6 +10,11 @@ import DeploymentNextSteps from "/snippets/deployment-next-steps.mdx"
   Check out the [Resourcing Guide](/deployment/getting_started/resourcing) before getting started with Docker.
 </Tip>
 
+<Note>
+  This guide covers managing the compose files manually. For a guided install with managed upgrades,
+  use the [installation scripts](/deployment/getting_started/quickstart) or the [Onyx CLI](/deployment/local/onyx_cli).
+</Note>
+
 ## Guide
 
 **Note:** On Windows, the commands will be slightly different but all the steps are the same.

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -101,10 +101,6 @@ For example, a fully non-interactive install pinned to a specific version:
 onyx-cli deploy install --tag v4.4.6 --no-prompt
 ```
 
-<Note>
-  `onyx-cli install-onyx` is a top-level alias for `onyx-cli deploy install`.
-</Note>
-
 ### Deployment directory
 
 New installs live in `~/.config/onyx` (XDG-aware).

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -10,9 +10,25 @@ The [Onyx CLI](/overview/onyx_anywhere/cli)
 includes a `deploy` command group that installs and manages a self-hosted Docker Compose deployment:
 a guided installer plus lifecycle commands for upgrading, inspecting, stopping, and removing the deployment.
 
-It is the recommended way to set up and manage a self-hosted deployment on Linux, macOS, and Windows,
-replacing the legacy `install.sh` / `install.ps1` [installation scripts](/deployment/getting_started/quickstart).
-Deployments created by those scripts are detected and [managed in place](#migrating-an-existing-deployment).
+It is the recommended way to set up and manage a self-hosted deployment on Linux, macOS, and Windows.
+The `install.sh` / `install.ps1` [installation scripts](/deployment/getting_started/quickstart)
+are thin wrappers that install the CLI and run `onyx-cli deploy install`, so both paths produce the same deployment.
+Deployments created by older versions of the scripts are detected and [managed in
+place](#migrating-an-existing-deployment).
+
+Compared to managing the [Docker Compose files](/deployment/local/docker) by hand, the CLI:
+
+- **Keeps the compose files in sync automatically** — `deploy upgrade` refreshes the compose files, overlays,
+  and nginx config to match the target version, so you never diff them against the repo yourself.
+- **Protects your customizations** — hand-edited files are detected via a checksum manifest and backed up before
+  they are ever overwritten, and your `.env` settings survive every upgrade.
+- **Steers debugging** — `deploy status` flags version drift and explains *why* a service is down
+  (restarts, exit code, OOM, last failing health probe),
+  and `deploy logs` finds the right compose files and overlays for you.
+- **Handles the environment** — it checks RAM, disk, and ports, installs Docker on Linux,
+  and generates secrets, instead of leaving prerequisites to a README.
+- **Has a convenient, discoverable interface** — guided prompts with sensible defaults, `--help` on every command,
+  and clear error messages, with `--no-prompt` and `--json` for automation.
 
 | Command | Description |
 |---------|-------------|
@@ -92,8 +108,8 @@ onyx-cli deploy install --tag v4.4.6 --no-prompt
 ### Deployment directory
 
 New installs live in `~/.config/onyx` (XDG-aware).
-Deployments created by the legacy `install.sh` script in `./onyx_data` are detected automatically and managed **in
-place** — no migration needed.
+Deployments created by older versions of the `install.sh` script in `./onyx_data` are detected automatically and managed
+**in place** — no migration needed.
 Pass `--dir` or set the `ONYX_DEPLOYMENT_DIR` environment variable to target a specific location.
 
 The directory holds the compose files, `.env`, and an `install-state.json` manifest recording the deployment mode,
@@ -181,11 +197,11 @@ Removes the Onyx containers, volumes, and the deployment directory.
 
 ## Migrating an existing deployment
 
-### From install.sh
+### From an older install.sh deployment
 
-Deployments created by the legacy `install.sh` script are managed in place — run the CLI from the directory containing
-`onyx_data` (or point `--dir` at it) and it takes over, no migration required.
-The script's mode flags map to dedicated commands:
+Today's `install.sh` runs the CLI, but older versions were standalone and installed into an `onyx_data` directory.
+Those deployments are managed in place — run the CLI from the directory containing `onyx_data` (or point `--dir` at it)
+and it takes over, no migration required. The old script's mode flags map to dedicated commands:
 
 | install.sh | Onyx CLI |
 |------------|----------|

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -10,10 +10,9 @@ The [Onyx CLI](/overview/onyx_anywhere/cli)
 includes a `deploy` command group that installs and manages a self-hosted Docker Compose deployment:
 a guided installer plus lifecycle commands for upgrading, inspecting, stopping, and removing the deployment.
 
-It is a cross-platform (Linux, macOS, Windows)
-implementation of the same guided install provided by the [installation
-scripts](/deployment/getting_started/quickstart), and it understands deployments created by those scripts.
-The scripts remain supported; the CLI will eventually replace them once it stabilizes.
+It is the recommended way to set up and manage a self-hosted deployment on Linux, macOS, and Windows,
+replacing the legacy `install.sh` / `install.ps1` [installation scripts](/deployment/getting_started/quickstart).
+Deployments created by those scripts are detected and [managed in place](#migrating-an-existing-deployment).
 
 | Command | Description |
 |---------|-------------|
@@ -180,10 +179,13 @@ Removes the Onyx containers, volumes, and the deployment directory.
   non-interactive runs require `--force`.
 </Warning>
 
-## Migrating from install.sh
+## Migrating an existing deployment
 
-Existing `install.sh` deployments are managed in place — just run the CLI from the directory containing `onyx_data` (or
-point `--dir` at it). The script's mode flags map to dedicated commands:
+### From install.sh
+
+Deployments created by the legacy `install.sh` script are managed in place — run the CLI from the directory containing
+`onyx_data` (or point `--dir` at it) and it takes over, no migration required.
+The script's mode flags map to dedicated commands:
 
 | install.sh | Onyx CLI |
 |------------|----------|
@@ -191,5 +193,58 @@ point `--dir` at it). The script's mode flags map to dedicated commands:
 | Re-run and type `update` | `onyx-cli deploy upgrade` |
 | `./install.sh --shutdown` | `onyx-cli deploy stop` |
 | `./install.sh --delete-data` | `onyx-cli deploy uninstall` |
+
+### Moving to ~/.config/onyx
+
+A legacy `onyx_data` install can also be relocated to the recommended `~/.config/onyx` location.
+Only configuration moves: chats, users,
+and documents live in named Docker volumes keyed by the compose project name (`onyx`), which stays the same,
+so the relocated deployment adopts them automatically.
+The one file that must be carried over is `.env` — it holds the secrets the database and object-store volumes were
+initialized with.
+
+```bash
+# From the directory containing onyx_data
+onyx-cli deploy stop
+mkdir -p ~/.config/onyx/deployment
+cp onyx_data/deployment/.env ~/.config/onyx/deployment/
+onyx-cli deploy install --dir ~/.config/onyx
+```
+
+Choose **Restart** to come back up on the version already pinned in `.env`, or **Upgrade** to move to a newer one.
+The compose files are downloaded fresh, so re-apply any hand edits you made to them.
+Once `onyx-cli deploy status` reports healthy, delete the old directory — it only holds configuration:
+
+```bash
+rm -rf onyx_data
+```
+
+<Note>
+  Deleting the old directory matters: when `onyx_data` exists in the working directory,
+  the CLI prefers it over `~/.config/onyx`. Once it is gone,
+  plain `onyx-cli deploy` commands find the new location without `--dir`.
+</Note>
+
+### From a manual docker compose setup
+
+A deployment you started by hand from the repo's `deployment/docker_compose` directory can be adopted the same way,
+as long as it uses the default compose project name (`onyx`, pinned in `docker-compose.yml`):
+
+```bash
+# From the directory with your docker-compose.yml
+docker compose down   # keeps the data volumes — do NOT pass -v
+mkdir -p ~/.config/onyx/deployment
+cp .env ~/.config/onyx/deployment/
+onyx-cli deploy install
+```
+
+The installer detects the copied `.env` as an existing deployment, downloads the managed compose files,
+and brings the stack back up on the existing volumes.
+
+<Warning>
+  Deployments launched under a different project name — the old `onyx-stack` name,
+  or any custom `-p` value — store their volumes under that prefix and are **not** adopted automatically.
+  Keep managing those with `docker compose` directly, or migrate the volume data manually before switching.
+</Warning>
 
 <DeploymentNextSteps />

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -125,11 +125,12 @@ config files already on disk are used as-is, and any that are missing are writte
 Staging the deployment directory from a connected install (below)
 is still recommended — the bundled copies match the CLI's own version, not necessarily the Onyx version being deployed.
 
-On a machine with internet access, install the target version with the same mode flags,
+On a machine with internet access,
+install the latest release with the same mode flags (or pin a specific version with `--tag`),
 then export the images the deployment resolved to:
 
 ```bash
-onyx-cli deploy install --tag v4.4.6
+onyx-cli deploy install
 cd ~/.config/onyx/deployment
 docker save -o onyx-images.tar $(docker compose config --images)
 ```
@@ -138,15 +139,16 @@ Copy `onyx-images.tar` and the `~/.config/onyx` directory to the offline host, t
 
 ```bash
 docker load -i onyx-images.tar
-onyx-cli deploy install --offline --tag v4.4.6
+onyx-cli deploy install --offline
 ```
 
+Without `--tag`,
+an offline install offers the newest released version whose images are already on the host — the one just loaded.
 Before starting anything,
 the installer verifies every image the deployment needs and names each one that is missing — load those with `docker
 load` and re-run.
 
 <Note>
-  Without `--tag`, an offline install offers the newest released version whose images are already on the host.
   `deploy upgrade --offline` works the same way for moving an air-gapped deployment to a newer staged version.
 </Note>
 

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -1,0 +1,189 @@
+---
+title: "Onyx CLI"
+description: "Install and manage a Docker Compose deployment with onyx-cli deploy"
+icon: "terminal"
+---
+
+import DeploymentNextSteps from "/snippets/deployment-next-steps.mdx"
+
+The [Onyx CLI](/overview/onyx_anywhere/cli)
+includes a `deploy` command group that installs and manages a self-hosted Docker Compose deployment:
+a guided installer plus lifecycle commands for upgrading, inspecting, stopping, and removing the deployment.
+
+It is a cross-platform (Linux, macOS, Windows)
+implementation of the same guided install provided by the [installation
+scripts](/deployment/getting_started/quickstart), and it understands deployments created by those scripts.
+The scripts remain supported; the CLI will eventually replace them once it stabilizes.
+
+| Command | Description |
+|---------|-------------|
+| `onyx-cli deploy install` | Install a new deployment, or restart / update an existing one |
+| `onyx-cli deploy upgrade` | Upgrade an existing deployment to a newer version |
+| `onyx-cli deploy status` | Show versions, containers, and health |
+| `onyx-cli deploy stop` | Stop the containers without removing any data |
+| `onyx-cli deploy logs` | Show service logs |
+| `onyx-cli deploy uninstall` | Permanently delete the deployment and all its data |
+
+## Prerequisites
+
+Install the CLI from PyPI:
+
+```shell
+pip install onyx-cli
+```
+
+See the [CLI overview](/overview/onyx_anywhere/cli) for other installation methods.
+No `onyx-cli configure` step is needed — the `deploy` commands work directly against your local Docker,
+not an Onyx server.
+
+<Tip>
+  Check out the [Resourcing Guide](/deployment/getting_started/resourcing) before getting started.
+</Tip>
+
+## Install
+
+```shell
+onyx-cli deploy install
+```
+
+The interactive installer asks two questions — the deployment mode (**Lite**, **Standard**, or **Standard + Craft**)
+and the version to deploy, prefilled with the latest release — while environment checks run in the background. It then:
+
+- Checks system resources (RAM, disk) and scans for a free host port
+- Installs Docker Engine and the compose plugin on Linux after confirmation;
+  starts Docker Desktop and waits for it on macOS; detects Docker and provides instructions on Windows
+- Creates a `.env` file from the template with randomly generated secrets
+- Pulls the Onyx images and starts the containers, waiting until every service reports healthy
+
+Re-running `deploy install` on an existing deployment asks a single question:
+**Restart** it as-is or **Upgrade** it to a newer version.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--lite` | Deploy Onyx Lite (no OpenSearch, Redis, or model servers) |
+| `--include-craft` | Enable [Onyx Craft](/deployment/local/craft_docker_compose) |
+| `--tag <version>` | Image tag to deploy (default: the latest Onyx release) |
+| `--dir <path>` | Deployment directory (default: `~/.config/onyx`, or an existing `./onyx_data`) |
+| `--no-prompt` | Run non-interactively with defaults applied to every prompt (for CI/automation) |
+| `--local` | Use existing config files on disk instead of downloading |
+| `--offline` | Deploy from images already on the host without any network access (implies `--local`) |
+| `--no-wait` | Return as soon as containers are started instead of waiting for health |
+| `--dry-run` | Show what would be done without making changes |
+| `--force` | Overwrite hand-edited managed files (a backup is kept) and recreate running services |
+| `--verbose` | Show detailed output for debugging |
+
+For example, a fully non-interactive install pinned to a specific version:
+
+```shell
+onyx-cli deploy install --tag v4.4.6 --no-prompt
+```
+
+<Note>
+  `onyx-cli install-onyx` is a top-level alias for `onyx-cli deploy install`.
+</Note>
+
+### Deployment directory
+
+New installs live in `~/.config/onyx` (XDG-aware).
+Deployments created by the legacy `install.sh` script in `./onyx_data` are detected automatically and managed **in
+place** — no migration needed.
+Pass `--dir` or set the `ONYX_DEPLOYMENT_DIR` environment variable to target a specific location.
+
+The directory holds the compose files, `.env`, and an `install-state.json` manifest recording the deployment mode,
+version, and a checksum of each managed file. No application data lives there — chats, users,
+and documents are stored in named Docker volumes.
+
+## Upgrade
+
+```shell
+onyx-cli deploy upgrade
+```
+
+Upgrades an existing deployment to the latest release, or to a specific version with `--tag`:
+
+```shell
+onyx-cli deploy upgrade --tag v4.4.6
+```
+
+The upgrade is designed to preserve your customizations:
+
+- Only the `IMAGE_TAG` line in `.env` is rewritten (plus `SANDBOX_BACKEND` when Craft is enabled) —
+  every other setting, including your edits, is kept.
+- Managed files (compose files, overlays, nginx config) are refreshed to match the target version.
+  Files you hand-edited are detected via the manifest, backed up,
+  and only overwritten after you confirm (or with `--force`).
+- Downgrades to an older version warn and require confirmation or `--force`.
+
+The running services keep serving while the new images download and are then recreated on the new version.
+`upgrade` accepts the same `--dir`, `--no-prompt`, `--local`, `--offline`, `--no-wait`, `--dry-run`,
+and `--verbose` flags as `install`.
+
+## Status
+
+```shell
+onyx-cli deploy status
+```
+
+Shows the installed version as recorded by the CLI, by `.env`,
+and by the running containers (drift between them is flagged), plus per-container status and health, the published port,
+and — for a service that is down — why (restarts, exit code, OOM, last failing health probe).
+
+`status` is read-only and works as a health probe: use `--json` for machine-readable output, and check the exit code.
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Everything is up and healthy |
+| `1` | Stopped or degraded |
+| `9` | No installation found |
+
+## Logs
+
+```shell
+onyx-cli deploy logs api_server
+```
+
+Shows service logs without needing to locate the deployment directory or remember which compose overlays it uses.
+Name one or more services to narrow the output, or pass none for all services.
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--follow` | Keep printing new log lines |
+| `--tail <n>` | Lines to show from the end of each log (default `200`, `all` for everything) |
+| `--since <time>` | Only logs since this point (e.g. `10m`, `2h`, or a timestamp) |
+
+## Stop
+
+```shell
+onyx-cli deploy stop
+```
+
+Stops the containers without removing them or any data. Start the deployment again with `onyx-cli deploy install`.
+
+## Uninstall
+
+```shell
+onyx-cli deploy uninstall
+```
+
+Removes the Onyx containers, volumes, and the deployment directory.
+
+<Warning>
+  This permanently deletes all user data and documents. Interactive runs must type `DELETE` to confirm;
+  non-interactive runs require `--force`.
+</Warning>
+
+## Migrating from install.sh
+
+Existing `install.sh` deployments are managed in place — just run the CLI from the directory containing `onyx_data` (or
+point `--dir` at it). The script's mode flags map to dedicated commands:
+
+| install.sh | Onyx CLI |
+|------------|----------|
+| `./install.sh` | `onyx-cli deploy install` |
+| Re-run and type `update` | `onyx-cli deploy upgrade` |
+| `./install.sh --shutdown` | `onyx-cli deploy stop` |
+| `./install.sh --delete-data` | `onyx-cli deploy uninstall` |
+
+<DeploymentNextSteps />

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -116,6 +116,37 @@ The directory holds the compose files, `.env`, and an `install-state.json` manif
 version, and a checksum of each managed file. No application data lives there — chats, users,
 and documents are stored in named Docker volumes.
 
+### Offline install
+
+`--offline` deploys entirely from what is already on the host — no release lookup, no config download,
+and no image pull. It implies `--local`, so both the images and the deployment directory must be staged in advance,
+and Docker must already be installed (the installer cannot install it without a network).
+
+On a machine with internet access, install the target version with the same mode flags,
+then export the images the deployment resolved to:
+
+```bash
+onyx-cli deploy install --tag v4.4.6
+cd ~/.config/onyx/deployment
+docker save -o onyx-images.tar $(docker compose config --images)
+```
+
+Copy `onyx-images.tar` and the `~/.config/onyx` directory to the offline host, then:
+
+```bash
+docker load -i onyx-images.tar
+onyx-cli deploy install --offline --tag v4.4.6
+```
+
+Before starting anything,
+the installer verifies every image the deployment needs and names each one that is missing — load those with `docker
+load` and re-run.
+
+<Note>
+  Without `--tag`, an offline install offers the newest released version whose images are already on the host.
+  `deploy upgrade --offline` works the same way for moving an air-gapped deployment to a newer staged version.
+</Note>
+
 ## Upgrade
 
 ```shell

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -18,16 +18,16 @@ place](#migrating-an-existing-deployment).
 
 Compared to managing the [Docker Compose files](/deployment/local/docker) by hand, the CLI:
 
-- **Keeps the compose files in sync automatically** — `deploy upgrade` refreshes the compose files, overlays,
+- **Keeps the compose files in sync automatically**: `deploy upgrade` refreshes the compose files, overlays,
   and nginx config to match the target version, so you never diff them against the repo yourself.
-- **Protects your customizations** — hand-edited files are detected via a checksum manifest and backed up before
+- **Protects your customizations**: hand-edited files are detected via a checksum manifest and backed up before
   they are ever overwritten, and your `.env` settings survive every upgrade.
-- **Steers debugging** — `deploy status` flags version drift and explains *why* a service is down
+- **Steers debugging**: `deploy status` flags version drift and explains *why* a service is down
   (restarts, exit code, OOM, last failing health probe),
   and `deploy logs` finds the right compose files and overlays for you.
-- **Handles the environment** — it checks RAM, disk, and ports, installs Docker on Linux,
+- **Handles the environment**: it checks RAM, disk, and ports, installs Docker on Linux,
   and generates secrets, instead of leaving prerequisites to a README.
-- **Has a convenient, discoverable interface** — guided prompts with sensible defaults, `--help` on every command,
+- **Has a convenient, discoverable interface**: guided prompts with sensible defaults, `--help` on every command,
   and clear error messages, with `--no-prompt` and `--json` for automation.
 
 | Command | Description |

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -119,8 +119,11 @@ and documents are stored in named Docker volumes.
 ### Offline install
 
 `--offline` deploys entirely from what is already on the host — no release lookup, no config download,
-and no image pull. It implies `--local`, so both the images and the deployment directory must be staged in advance,
-and Docker must already be installed (the installer cannot install it without a network).
+and no image pull. The images must be loaded in advance,
+and Docker must already be installed (the installer cannot install it without a network). It implies `--local`:
+config files already on disk are used as-is, and any that are missing are written from copies bundled with the CLI.
+Staging the deployment directory from a connected install (below)
+is still recommended — the bundled copies match the CLI's own version, not necessarily the Onyx version being deployed.
 
 On a machine with internet access, install the target version with the same mode flags,
 then export the images the deployment resolved to:

--- a/deployment/local/onyx_cli.mdx
+++ b/deployment/local/onyx_cli.mdx
@@ -29,6 +29,12 @@ The scripts remain supported; the CLI will eventually replace them once it stabi
 Install the CLI from PyPI:
 
 ```shell
+uv tool install onyx-cli
+```
+
+Or with pip:
+
+```shell
 pip install onyx-cli
 ```
 
@@ -46,8 +52,8 @@ not an Onyx server.
 onyx-cli deploy install
 ```
 
-The interactive installer asks two questions — the deployment mode (**Lite**, **Standard**, or **Standard + Craft**)
-and the version to deploy, prefilled with the latest release — while environment checks run in the background. It then:
+The interactive installer asks two questions — the deployment mode (**Lite** or **Standard**) and the version to deploy,
+prefilled with the latest release — while environment checks run in the background. It then:
 
 - Checks system resources (RAM, disk) and scans for a free host port
 - Installs Docker Engine and the compose plugin on Linux after confirmation;
@@ -63,7 +69,7 @@ Re-running `deploy install` on an existing deployment asks a single question:
 | Flag | Description |
 |------|-------------|
 | `--lite` | Deploy Onyx Lite (no OpenSearch, Redis, or model servers) |
-| `--include-craft` | Enable [Onyx Craft](/deployment/local/craft_docker_compose) |
+| `--include-craft` | Enable [Onyx Craft](/deployment/local/craft_docker_compose) — Craft is opt-in via this flag only and is not offered by the interactive prompt |
 | `--tag <version>` | Image tag to deploy (default: the latest Onyx release) |
 | `--dir <path>` | Deployment directory (default: `~/.config/onyx`, or an existing `./onyx_data`) |
 | `--no-prompt` | Run non-interactively with defaults applied to every prompt (for CI/automation) |

--- a/docs.json
+++ b/docs.json
@@ -86,8 +86,8 @@
           {
             "group": "Deploy Locally",
             "pages": [
-              "deployment/local/docker",
               "deployment/local/onyx_cli",
+              "deployment/local/docker",
               "deployment/local/kubernetes",
               "deployment/local/terraform",
               "deployment/local/opensearch"

--- a/docs.json
+++ b/docs.json
@@ -87,6 +87,7 @@
             "group": "Deploy Locally",
             "pages": [
               "deployment/local/docker",
+              "deployment/local/onyx_cli",
               "deployment/local/kubernetes",
               "deployment/local/terraform",
               "deployment/local/opensearch"

--- a/overview/onyx_anywhere/cli.mdx
+++ b/overview/onyx_anywhere/cli.mdx
@@ -87,6 +87,7 @@ onyx-cli validate-config
 | `onyx-cli agents` | List available agents |
 | `onyx-cli configure` | Configure server URL and API key |
 | `onyx-cli validate-config` | Validate configuration and test connection |
+| `onyx-cli deploy` | Install and manage a self-hosted Onyx deployment |
 
 ### Interactive Chat
 
@@ -129,6 +130,19 @@ onyx-cli agents --json
 ```
 
 Prints a table of available agent IDs, names, and descriptions.
+
+### Self-Hosted Deployment
+
+The `deploy` command group installs and manages a self-hosted Docker Compose deployment of Onyx — a guided installer
+plus `upgrade`, `status`, `logs`, `stop`, and `uninstall` commands:
+
+```shell
+onyx-cli deploy install
+```
+
+<Card title="Deploy with the Onyx CLI" icon="server" href="/deployment/local/onyx_cli">
+  Full documentation for `onyx-cli deploy` and its lifecycle commands.
+</Card>
 
 ## Slash Commands (Interactive TUI)
 

--- a/overview/onyx_anywhere/cli.mdx
+++ b/overview/onyx_anywhere/cli.mdx
@@ -15,18 +15,18 @@ it provides both an interactive TUI and non-interactive commands for scripting a
 ### PyPI (recommended)
 
 ```shell
-pip install onyx-cli
+uv tool install onyx-cli
 ```
 
-Or with uv:
+Or with pip:
 
 ```shell
-uv pip install onyx-cli
+pip install onyx-cli
 ```
 
 {/* TODO: Replace with actual PyPI URL once published */}
 <Card title="PyPI Package" icon="python" href="https://pypi.org/project/onyx-cli/">
-  pip install onyx-cli
+  uv tool install onyx-cli
 </Card>
 
 ### Build from Source

--- a/snippets/quickstart.mdx
+++ b/snippets/quickstart.mdx
@@ -52,7 +52,7 @@ The same guided install also ships inside the [Onyx CLI](/overview/onyx_anywhere
 and will eventually replace the installation scripts:
 
 ```bash
-pip install onyx-cli && onyx-cli deploy install
+uv tool install onyx-cli && onyx-cli deploy install
 ```
 
 It detects existing script-based installs and manages them in place, and adds lifecycle commands for upgrading,

--- a/snippets/quickstart.mdx
+++ b/snippets/quickstart.mdx
@@ -1,7 +1,29 @@
-## Installation Scripts
+## Onyx CLI
 
-The scripts provide a guided installation in Docker Compose and will let you select between Lite and Standard during
-setup.
+The recommended way to install Onyx is the guided installer built into the [Onyx CLI](/overview/onyx_anywhere/cli):
+
+```bash
+uv tool install onyx-cli && onyx-cli deploy install
+```
+
+The installer will:
+
+- Check your system resources and requirements (installing Docker on Linux if needed)
+- Let you choose between **Lite** and **Standard** deployment modes
+- Prompt for the version of Onyx to deploy
+- Set up the deployment configuration in `~/.config/onyx`
+- Pull the Onyx containers, start them, and wait until every service is healthy
+
+After installation, the same command group manages the deployment: `onyx-cli deploy upgrade`, `status`, `logs`, `stop`,
+and `uninstall`.
+
+<Card title="Deploy with the Onyx CLI" icon="terminal" href="/deployment/local/onyx_cli">
+  Full documentation for `onyx-cli deploy` and its lifecycle commands.
+</Card>
+
+## Installation Scripts (legacy)
+
+The installation scripts provide the same guided install and remain available:
 
 <Tabs>
   <Tab title="Linux / macOS">
@@ -29,38 +51,11 @@ Or download the script and run it manually:
   </Card>
 </CardGroup>
 
-<Note>
-  The install script can also be used to **upgrade** an existing deployment.
-  Re-running the script will detect your current installation and prompt you to update to the latest version.
-</Note>
-
-The script will do the following:
-- Check your system resources and requirements
-- Let you choose between **Lite** and **Standard** deployment modes
-- Pull the necessary deployment and configuration files
-- Prompt for the version of Onyx to deploy and other basic configuration
-- Pull the Onyx containers and start them in Docker
-
 <Info>
-  The script will create a directory called **onyx_data** and there will also be a README in there with additional
-  information.
+  The script will create a directory called **onyx_data** with a README containing additional information.
+  The Onyx CLI detects deployments created by the scripts and manages them in place — see [migrating an existing
+  deployment](/deployment/local/onyx_cli#migrating-an-existing-deployment).
 </Info>
-
-## Onyx CLI (alternative)
-
-The same guided install also ships inside the [Onyx CLI](/overview/onyx_anywhere/cli)
-and will eventually replace the installation scripts:
-
-```bash
-uv tool install onyx-cli && onyx-cli deploy install
-```
-
-It detects existing script-based installs and manages them in place, and adds lifecycle commands for upgrading,
-checking health, viewing logs, stopping, and uninstalling the deployment.
-
-<Card title="Deploy with the Onyx CLI" icon="terminal" href="/deployment/local/onyx_cli">
-  Full documentation for `onyx-cli deploy` and its lifecycle commands.
-</Card>
 
 ## Next Steps
 

--- a/snippets/quickstart.mdx
+++ b/snippets/quickstart.mdx
@@ -46,6 +46,22 @@ The script will do the following:
   information.
 </Info>
 
+## Onyx CLI (alternative)
+
+The same guided install also ships inside the [Onyx CLI](/overview/onyx_anywhere/cli)
+and will eventually replace the installation scripts:
+
+```bash
+pip install onyx-cli && onyx-cli deploy install
+```
+
+It detects existing script-based installs and manages them in place, and adds lifecycle commands for upgrading,
+checking health, viewing logs, stopping, and uninstalling the deployment.
+
+<Card title="Deploy with the Onyx CLI" icon="terminal" href="/deployment/local/onyx_cli">
+  Full documentation for `onyx-cli deploy` and its lifecycle commands.
+</Card>
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/snippets/quickstart.mdx
+++ b/snippets/quickstart.mdx
@@ -21,9 +21,11 @@ and `uninstall`.
   Full documentation for `onyx-cli deploy` and its lifecycle commands.
 </Card>
 
-## Installation Scripts (legacy)
+## Installation Scripts
 
-The installation scripts provide the same guided install and remain available:
+The installation scripts are thin wrappers around the CLI:
+they install `onyx-cli` if needed and run `onyx-cli deploy install`, producing the same deployment as the command above.
+Use them when you want a single copy-paste one-liner:
 
 <Tabs>
   <Tab title="Linux / macOS">
@@ -52,8 +54,8 @@ Or download the script and run it manually:
 </CardGroup>
 
 <Info>
-  The script will create a directory called **onyx_data** with a README containing additional information.
-  The Onyx CLI detects deployments created by the scripts and manages them in place — see [migrating an existing
+  Older versions of the scripts were standalone and installed into a directory called **onyx_data**.
+  The Onyx CLI detects those deployments and manages them in place — see [migrating an existing
   deployment](/deployment/local/onyx_cli#migrating-an-existing-deployment).
 </Info>
 


### PR DESCRIPTION
## Description

[onyx#13522](https://github.com/onyx-dot-app/onyx/pull/13522) moved the guided docker-compose installer into `onyx-cli` as a `deploy` command group. This documents it, positioning the CLI as the default install interface — the docs assume `install.sh` / `install.ps1` are now thin wrappers that install the CLI and run `onyx-cli deploy install`:

- **New page** `deployment/local/onyx_cli.mdx` (Deployment → Deploy Locally, first entry, above Docker): covers `deploy install` / `upgrade` / `status` / `logs` / `stop` / `uninstall` with flag tables, a "why the CLI over managing compose files by hand" list (auto-synced managed files, hand-edit protection via the checksum manifest, `status`/`logs` debugging steering, environment checks, guided prompts + `--help`/`--json`), the deployment directory semantics (`~/.config/onyx`, older-script `onyx_data` managed in place, `--dir` / `ONYX_DEPLOYMENT_DIR`), the upgrade safety behavior (only `IMAGE_TAG` rewritten, hand-edited files backed up, downgrade guard), `status` probe exit codes, and migration guides: the old install.sh → CLI command mapping, relocating a legacy `onyx_data` install to `~/.config/onyx`, and adopting a manual docker compose setup (both rely on the pinned `onyx` compose project name keeping data volumes path-independent, with `.env` carried over for the volume secrets).
- **Quickstart snippet**: leads with `uv tool install onyx-cli && onyx-cli deploy install`; the installation scripts are described as wrappers around the CLI kept for one-liner convenience, with a note that older standalone script versions created `onyx_data`.
- **CLI overview page** (`overview/onyx_anywhere/cli.mdx`): adds `deploy` to the command table plus a short section linking to the new page; `uv tool install` is now the preferred install command.
- **Craft compose guide**: installer commands switch to `onyx-cli deploy install --include-craft` and paths use the CLI's default deployment directory (older-script note included).
- **Docker guide**: notes the CLI as the guided alternative, including adopting an existing manual setup.

Craft is documented as opt-in via `--include-craft` only (not offered in the interactive mode prompt), per [onyx#13589](https://github.com/onyx-dot-app/onyx/pull/13589) — that PR is still open, so this should merge after it lands. The docs also assume the wrapper-ized `install.sh` — as of writing, `install.sh` on onyx main is still the standalone script, so this should additionally land after that change ships.

Command names, flags, defaults, and exit codes were taken from the merged `cli/cmd/deploy*.go` sources; the migration guidance was verified against `paths.go` resolution order, the installer's rerun path (a pre-existing `deployment/.env` is preserved), and the `name: onyx` pin in the generated compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
