### PR TITLE
fix: remove Box connector page icon

### DIFF
--- a/admins/connectors/official/box.mdx
+++ b/admins/connectors/official/box.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Box"
 description: "Index files and web links from Box"
-icon: "box"
 ---
 
 The Box connector indexes files that a Box service account or managed user can access.


### PR DESCRIPTION
## Summary

- Remove the Box icon from the connector admin documentation page so it matches the other completed connector pages.

## How was this tested
