### PR TITLE
docs(agent-wiki): admin section updates

### DIFF
--- a/agent-wiki/admin/language_models.mdx
+++ b/agent-wiki/admin/language_models.mdx
@@ -21,6 +21,20 @@ The model is doing more work than a chat box. It:
 
 So provider choice and rate limits affect the responsiveness of the whole product, not one feature.
 
+<Note>
+  **Choosing a model.** A capable model is worth it here — it's behind chat, trigger evaluation,
+  and every automated edit. Cost stays reasonable because the one genuinely high-volume job, ingestion,
+  can run on its own cheaper model (below).
+</Note>
+
+## A cheaper model for ingestion
+
+Ingestion generates more model calls than everything else combined,
+and its work — matching pushed documents to pages and merging them in — doesn't need your strongest model.
+On the [Onyx Integration](/agent-wiki/admin/onyx_integration)
+page you can select a separate model just for the ingestion pipeline; pick a cheap, fast one (e.g. Luna)
+and keep the more capable default for daily usage. The ingestion model has to come from the providers enabled here.
+
 ## Per-user overrides
 
 Users can pick a different model for their own chats under **Settings**.

--- a/agent-wiki/admin/onyx_integration.mdx
+++ b/agent-wiki/admin/onyx_integration.mdx
@@ -7,7 +7,56 @@ icon: "plug"
 Connect an Onyx instance and its indexed documents flow into the wiki automatically.
 Rather than landing as a dump of new pages, a built-in agent finds the right existing page and updates it.
 
-Go to **Admin → Onyx Connection**, then copy the base URL and API key shown there into your Onyx environment variables.
+## Setup
+
+Go to **Admin → Onyx Integration** and copy the two connection details shown there:
+the ingest URL (it ends in `/api/documents/ingest`) and the API key.
+Then configure your Onyx deployment to push with them, in one of two ways.
+
+### Recommended: a Document Push hook (Enterprise)
+
+On Onyx Enterprise Edition,
+create a **Document Push hook** under **Admin → Hooks** in Onyx with the ingest URL and API key.
+Everything is managed from the UI — no deployment changes,
+no restart — and failed pushes are recorded in the hook execution log so delivery problems are visible.
+
+### Alternative: environment variables (all editions)
+
+If you're not on Enterprise (or prefer config-driven setup),
+set the connection details as environment variables in your Onyx deployment and restart it:
+
+| Variable | Required | What it is |
+| --- | --- | --- |
+| `DOCUMENT_PUSH_ENDPOINT_URL` | yes | The ingest URL copied from the admin page. Setting it is what turns the push on. |
+| `DOCUMENT_PUSH_API_KEY` | yes | The API key copied from the admin page, sent as a bearer token. |
+| `DOCUMENT_PUSH_TIMEOUT_SECONDS` | no | Per-push timeout. Defaults to 30. |
+
+The two mechanisms are either/or, never both: when the environment variable is set,
+it wins and the hook is not consulted. Push failures on this path go to the service logs only.
+
+### What gets pushed
+
+Either way, every document a **public** connector successfully indexes is pushed to the wiki.
+The push is fire-and-forget: a failure is logged on the Onyx side and never blocks or fails indexing.
+It also doesn't fire during a connector's initial from-the-beginning run — only on the incremental updates after it,
+which is what keeps the wiki current without replaying your whole corpus.
+Document push works on single-tenant deployments only.
+
+## Ingest settings
+
+Below the connection details, the same admin page carries the wiki-side knobs for the pipeline:
+
+- **Max document size** (default 100,000 characters). Pushes larger than this are rejected outright —
+  and since the Onyx push is fire-and-forget, a rejected document doesn't come back on its own.
+  If your sources include long documents like meeting transcripts, raise this before connecting them.
+- **Auto-update health.** Two guardrails against pages that auto-update too often, both counted over
+  a sliding 24-hour window:
+  - **Default warning threshold** (default 30/24h). A page crossing it puts an event in the activity
+    feed and notifies its owner — advisory only, updates continue. This is just the wiki-wide default:
+    owners can override it per page from the page's [Update Policy](/agent-wiki/using/update_policies#update-health)
+    panel.
+  - **Auto-update cap** (default 100/24h). The hard limit. A page over the cap has further ingestion
+    updates skipped until its 24-hour count falls back under. Set it to 0 to disable the cap.
 
 ## How incoming documents are handled
 
@@ -21,10 +70,17 @@ Two controls govern it:
 - **Page instructions.** Free-text guidance the updater honors when it does edit — *"keep entries terse"*, *"never
   touch the SLA table"*.
 
+The pipeline doesn't have to run on the default model. You can select a model just for ingestion here,
+from the pool enabled under [Language Models](/agent-wiki/admin/language_models)
+— and since ingestion is high-volume background work, a cheaper model (e.g. Luna)
+than your daily-usage default is usually the right choice.
+
 <Warning>
   **Push organization-public sources only.** Wiki ingestion is not permission-aware yet:
   content from a permission-synced or private Onyx connector would land in the wiki without carrying its access
-  restrictions along. Keep those connectors out of wiki ingestion until that changes.
+  restrictions along.
+  Keep those connectors out of wiki ingestion until that changes — permission-aware ingestion is on the roadmap and
+  coming soon.
 </Warning>
 
 ## Related

--- a/agent-wiki/admin/overview.mdx
+++ b/agent-wiki/admin/overview.mdx
@@ -14,7 +14,7 @@ The first account created on a new instance is promoted to admin automatically.
 | Section | Purpose |
 | --- | --- |
 | [Language Models](/agent-wiki/admin/language_models) | Provider credentials and the model agents use |
-| Web Search & Crawl | Lets agents reach the web |
+| [Web Search](/agent-wiki/admin/web_search) | Lets agents search the web and read pages |
 | [Document Templates](/agent-wiki/admin/templates) | Named starting points for new pages |
 | [Auto Organize](/agent-wiki/automate/auto_organize) | Structural cleanup sweeps and the master switch |
 | [Onyx Integration](/agent-wiki/admin/onyx_integration) | Push documents from Onyx into the wiki |

--- a/agent-wiki/admin/status.mdx
+++ b/agent-wiki/admin/status.mdx
@@ -8,9 +8,12 @@ Two pages under **Admin → Statistics**.
 
 ## Status
 
-**Admin → Status** reports the health of the system's moving parts.
+**Admin → Status** reports backend liveness and the depth of every background work queue, refreshing every few seconds.
+Background work is split across dedicated queues — document reconciliation, trigger evaluations, co-edit checkpointing,
+the two Auto Organize lanes, and lightweight maintenance — so one backlog can't starve the others.
+Each queue shows its pending work against a capacity limit, broken down into ready, scheduled, and in-flight counts.
 
-The one worth understanding is the **background workers**, because their failures are silent rather than loud.
+The queues are worth watching because **background worker failures are silent rather than loud**.
 If workers aren't running, the application still serves pages normally while a surprising amount stops happening:
 
 - Triggers never fire, on updates or on a schedule

--- a/agent-wiki/admin/templates.mdx
+++ b/agent-wiki/admin/templates.mdx
@@ -5,18 +5,26 @@ icon: "file-lines"
 ---
 
 Templates are named starting points users pick when creating a page — a project brief, a meeting record, a runbook.
-Manage them under **Admin → Document Templates**.
+Manage them under **Admin → Wiki Templates**.
 
 ## Templates carry policy, not just text
 
 Beyond the body, each template can set a default [update policy](/agent-wiki/using/update_policies)
-applied to every page created from it: auto-update on or off, plus update instructions.
+applied to every page created from it: auto-update on or off, update instructions,
+and whether [Auto Organize](/agent-wiki/automate/auto_organize) may manage the page without asking.
 
 This is more useful than it first appears. A "Meeting Notes" template can ship with automatic updates **off**,
 so records of what was said never get rewritten later — without anyone remembering to set that per page.
 A "Service Runbook" template can ship with instructions like *"keep the escalation table intact"* already attached.
 
 Getting the posture right at creation is far more reliable than auditing it afterwards.
+
+## The Blank template
+
+Every page starts from a template.
+Creating one without picking anything uses the built-in **Blank** template — an empty body with auto-update off.
+It's system-managed, so it can't be renamed or deleted, and it doesn't appear in the admin list;
+there's nothing about it to configure.
 
 ## Templates and agents
 

--- a/agent-wiki/admin/users_and_groups.mdx
+++ b/agent-wiki/admin/users_and_groups.mdx
@@ -19,9 +19,11 @@ Admins bypass page-level permission checks, so keep the admin set small.
 ## Groups and page permissions
 
 Groups are how you grant access to parts of the wiki without naming individuals on every page.
-Permissions are stored per path and inherit down the tree,
-the same way [update policies](/agent-wiki/using/update_policies)
-do — grant on a folder and everything beneath it follows, override on a specific page or subfolder.
+Permissions are stored per path, and a grant on a folder cascades to everything beneath it.
+But unlike [update policies](/agent-wiki/using/update_policies), grants are **additive, with no deny**:
+a more specific grant can open up extra access on one page,
+but you can't grant a folder and then carve a single page out of it. When part of a folder needs to stay restricted,
+grant at the narrower scopes from the start.
 
 ## Permissions reach further than the page
 

--- a/agent-wiki/admin/web_search.mdx
+++ b/agent-wiki/admin/web_search.mdx
@@ -1,0 +1,25 @@
+---
+title: "Web Search"
+description: "Give agents access to the public web"
+icon: "globe"
+---
+
+Out of the box, agents only know what's in the wiki.
+**Admin → Web Search** connects them to the public web through two providers, each with its own API key:
+
+- **[Serper](https://serper.dev)** answers search queries — this is what powers the `web_search` tool.
+- **[Firecrawl](https://firecrawl.dev)** fetches full page contents — this is what powers the
+  `open_urls` tool, so an agent can actually read a result rather than just see its snippet.
+
+Keys are stored encrypted in the database and never echoed back to the browser.
+
+## What it unlocks
+
+With the keys in place,
+agents can ground their work in sources outside the wiki — verify a claim before writing it into a page,
+pull details from a linked ticket or announcement, or answer chat questions the wiki alone can't.
+
+Each capability follows its own key: with only Serper configured, agents can search but not open the results;
+with only Firecrawl, they can open URLs they already have but not search for them.
+A missing key doesn't produce errors — the corresponding tool simply isn't offered to agents,
+the same way [AI features sit idle](/agent-wiki/admin/language_models) without a model provider.

--- a/docs.json
+++ b/docs.json
@@ -639,6 +639,7 @@
             "pages": [
               "agent-wiki/admin/overview",
               "agent-wiki/admin/language_models",
+              "agent-wiki/admin/web_search",
               "agent-wiki/admin/templates",
               "agent-wiki/admin/users_and_groups",
               "agent-wiki/admin/onyx_integration",


### PR DESCRIPTION
Stacked on #430 — splits the admin-section work into its own PR.

## What's here

- **Language Models**: encourage a capable default model; new section on selecting a separate, cheaper model for the ingestion pipeline (picked on the Onyx Integration page, from the enabled provider pool)
- **Onyx Integration**: full setup docs — Document Push hook first (recommended, EE), env-var config as the alternative (`DOCUMENT_PUSH_ENDPOINT_URL` / `_API_KEY` / `_TIMEOUT_SECONDS`), what gets pushed and when; ingest settings (max document size) and auto-update health defaults (warning threshold 30/24h, cap 100/24h); note that permission-aware ingestion is coming soon
- **Status & Usage**: match the current Health page — backend liveness plus per-queue depth across the six background queues
- **Document Templates**: Wiki Templates nav name, Auto Organize default on templates, the built-in Blank template
- **Users & Groups**: fix — ACL grants are additive with no explicit deny; a folder grant can't be carved out per page (previously described as overridable like update policies)
- **Web Search** (new page): Serper for search, Firecrawl for page contents, per-key tool availability; linked from the admin overview and nav

All behavior verified against the agent-wiki repo code.
