### PR TITLE
docs(desktop): remove Global keyboard shortcuts from feature lists

### DIFF
--- a/deployment/local/desktop_app.mdx
+++ b/deployment/local/desktop_app.mdx
@@ -10,7 +10,6 @@ and Linux.
 Features include:
 
 - Quick-launch from system tray or dock
-- Global keyboard shortcuts
 - Desktop notifications
 
 <img className="rounded-image" src="/assets/deployment/onyx_desktop_app.png" alt="Onyx Desktop App"/>

--- a/overview/onyx_anywhere/desktop_app.mdx
+++ b/overview/onyx_anywhere/desktop_app.mdx
@@ -10,7 +10,6 @@ Access your organization's knowledge base without opening a browser:
 Features include:
 
 - Quick-launch from your system tray or dock
-- Global keyboard shortcuts
 - Desktop notifications
 
 <img className="rounded-image" src="/assets/overview/onyx_anywhere/desktop_app.png" alt="Onyx Desktop App"/>


### PR DESCRIPTION
## Description

Removes the "Global keyboard shortcuts" bullet from the two desktop app doc pages (`overview/onyx_anywhere/desktop_app.mdx` and `deployment/local/desktop_app.mdx`).

The desktop app does not implement global shortcuts — there is no `tauri-plugin-global-shortcut` dependency or shortcut registration in `desktop/src-tauri` (only in-window menu accelerators). Customers have flagged that the docs advertise a feature that doesn't exist, so this removes the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)