### PR TITLE
docs(deployment): document JWT_PUBLIC_KEY_URL header auth

### DIFF
--- a/deployment/authentication/jwt.mdx
+++ b/deployment/authentication/jwt.mdx
@@ -1,0 +1,151 @@
+---
+title: "JWT Header Auth"
+description: "Authenticate API requests with JWTs minted by your own identity provider"
+icon: "key"
+---
+
+Onyx can accept a JWT that your identity provider or API gateway mints, and use it to authenticate a request.
+This is useful when another system already holds the user's identity and calls Onyx on their behalf — for example an API
+gateway, a portal, or a service that fronts Onyx for its own users.
+
+Set `JWT_PUBLIC_KEY_URL` to a URL that serves the public key material for your token issuer. When the variable is set,
+Onyx accepts a signed JWT in the `Authorization` header:
+
+```
+Authorization: Bearer <JWT>
+```
+
+<Note>
+  This is a supported configuration. See [Support and stability](#support-and-stability) below.
+</Note>
+
+## Setup
+
+<Steps>
+  <Step title="Publish your public key">
+    Your identity provider must serve the verification key at a URL that the Onyx API server can reach.
+    Onyx accepts two formats:
+
+    - **JWKS** — a JSON document with a `keys` array. This is what Microsoft Entra ID, Okta, Auth0,
+    and most other providers publish at their `jwks_uri`.
+    - **PEM** — a single PEM-encoded RSA public key.
+
+    Onyx picks the format from the response. A response with `Content-Type: application/json`,
+    or a body that starts with `{`, is read as JWKS. Any other body is read as PEM.
+
+    <Tip>
+      Most identity providers list the JWKS URL in their OIDC discovery document at
+      `https://<YOUR_IDP>/.well-known/openid-configuration`, under the `jwks_uri` field.
+    </Tip>
+  </Step>
+
+  <Step title="Configure Onyx">
+    Set the variable in your `.env` or `values.yaml` file (Docker and Kubernetes, respectively).
+
+      ```bash .env
+      JWT_PUBLIC_KEY_URL=https://<YOUR_IDP>/.well-known/jwks.json
+      ```
+
+      ```yaml values.yaml
+      configMap:
+        JWT_PUBLIC_KEY_URL: https://<YOUR_IDP>/.well-known/jwks.json
+      ```
+
+    Restart the API server to apply the change.
+  </Step>
+
+  <Step title="Send a request">
+    Put the token in the `Authorization` header of any Onyx API call. `GET /api/me` returns the user that Onyx resolved,
+    so it is a good first check.
+
+      ```bash
+      curl https://<YOUR_ONYX_DOMAIN>/api/me \
+        -H "Authorization: Bearer <JWT>"
+      ```
+  </Step>
+</Steps>
+
+## Token requirements
+
+| Requirement    | Value                                                                        |
+| -------------- | ---------------------------------------------------------------------------- |
+| Signature      | RS256                                                                        |
+| Identity claim | The first valid email address in `email`, `preferred_username`, then `upn`   |
+| Expiry         | `exp` is enforced. Expired tokens are rejected                                |
+| Audience       | `aud` and `iss` are **not** checked                                          |
+
+The address in the identity claim is normalized and lowercased. It becomes the Onyx user's email.
+
+<Warning>
+  Onyx does not check the `aud` or `iss` claims. Any token that your configured key signs is accepted,
+  even if it was minted for a different application. Publish a key that only signs tokens for Onyx,
+  or make sure every consumer of that key is equally trusted.
+</Warning>
+
+### Key selection and rotation
+
+When the URL serves JWKS, Onyx selects the key by the token header `kid`, then by `x5t`.
+If neither matches and the document holds exactly one key, Onyx uses that key.
+
+Onyx caches the fetched key material. If verification fails, Onyx clears the cache, fetches the URL again,
+and retries once. Routine key rotation therefore needs no restart.
+
+## User handling
+
+A request authenticated by JWT is treated like any other logged-in user.
+
+- **Just-in-time provisioning.** If no Onyx user has that email, Onyx creates one. The account is
+  marked verified and gets a random password it never uses.
+- **Existing users.** If the email belongs to an existing user, that user is returned. Deactivated
+  users are rejected. Accounts that are not web-login accounts are rejected.
+- **Access policies still apply.** The email must satisfy the same invite allowlist and
+  `VALID_EMAIL_DOMAINS` rules as every other login path.
+- **Session expiry.** With `TRACK_EXTERNAL_IDP_EXPIRY=true`, Onyx stores the token's `exp` as the
+  user's external IdP expiry.
+
+A newly provisioned user has no elevated permissions.
+Grant admin or curator access from the **Admin Panel → Users** page,
+or manage access through [SCIM](/deployment/authentication/scim).
+
+## Precedence
+
+A valid Onyx session cookie takes priority. Onyx reads the `Authorization` header only when the request has no session.
+
+API keys and personal access tokens use the same header. Onyx tries the JWT path first,
+and a value that is not a valid RS256 JWT falls through to the API key and personal access token paths.
+Those credentials keep working unchanged when `JWT_PUBLIC_KEY_URL` is set.
+
+## Support and stability
+
+`JWT_PUBLIC_KEY_URL` is a documented and supported configuration option.
+Onyx treats it like every other published setting on this page:
+
+- The variable name, the `Authorization: Bearer` header, the RS256 requirement, the accepted key
+  formats, and the identity claim order are part of the documented interface.
+- Automated tests cover the behavior described above — existing-user login, just-in-time
+  provisioning, rejection of tokens signed by an unknown key, rejection of expired tokens,
+  and key rotation without a restart.
+- If a future release changes or replaces this option, the change is called out in the release
+  notes for that release, together with the mechanism that replaces it.
+
+<Note>
+  If you plan to build an integration on this option, [contact us](/deployment/miscellaneous/contact_us).
+  We are happy to review your design and tell you about anything on the roadmap that touches it.
+</Note>
+
+## Troubleshooting
+
+Onyx logs every verification failure on the API server. Check `api_server` logs for these messages:
+
+| Log message                                        | Cause                                                              |
+| -------------------------------------------------- | ------------------------------------------------------------------ |
+| `JWT_PUBLIC_KEY_URL is not set`                    | The variable is missing or empty                                   |
+| `Failed to fetch JWT public key`                   | Onyx cannot reach the URL. Check egress rules and TLS              |
+| `JWT public key URL returned invalid JSON`         | The response looks like JSON but does not parse                    |
+| `no JWKS 'keys' field was found`                   | The JSON response is not a JWKS document                           |
+| `No matching JWK found for token header`           | The token `kid` is absent from the JWKS document                   |
+| `Invalid JWT token`                                | Bad signature, expired token, or an algorithm other than RS256     |
+| `no email claim found`                             | None of `email`, `preferred_username`, or `upn` holds a valid email |
+
+A request that fails JWT verification is not rejected outright. It continues as an unauthenticated request,
+and the endpoint returns `401` if it needs a user.

--- a/deployment/authentication/jwt.mdx
+++ b/deployment/authentication/jwt.mdx
@@ -16,7 +16,8 @@ Authorization: Bearer <JWT>
 ```
 
 <Note>
-  This is a supported configuration. See [Support and stability](#support-and-stability) below.
+  This option is part of Onyx Community Edition. It needs no Enterprise license,
+  and it works the same way in both editions. See [Support and stability](#support-and-stability) below.
 </Note>
 
 ## Setup
@@ -103,9 +104,17 @@ A request authenticated by JWT is treated like any other logged-in user.
 - **Session expiry.** With `TRACK_EXTERNAL_IDP_EXPIRY=true`, Onyx stores the token's `exp` as the
   user's external IdP expiry.
 
-A newly provisioned user has no elevated permissions.
-Grant admin or curator access from the **Admin Panel → Users** page,
-or manage access through [SCIM](/deployment/authentication/scim).
+A user provisioned this way gets no elevated permissions, with one exception:
+the **first** user on an empty instance becomes an admin, whichever login path creates them.
+Grant admin or curator access to anyone else from the **Admin Panel → Users** page.
+
+<Info>
+  Enterprise Edition adds two behaviors on this path. Emails in the default-admin list are made admins at creation.
+  Provisioning a new user also consumes a license seat,
+  so a login for an unknown user fails once the workspace reaches its seat limit.
+  Community Edition applies no seat limit.
+  Enterprise Edition can also manage access through [SCIM](/deployment/authentication/scim).
+</Info>
 
 ## Precedence
 

--- a/deployment/configuration/configuration.mdx
+++ b/deployment/configuration/configuration.mdx
@@ -362,6 +362,12 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
     Disabled by default for backwards compatibility.
   </Accordion>
 
+  <Accordion title="JWT Header Auth">
+    `JWT_PUBLIC_KEY_URL`: URL that serves the public key material (JWKS or PEM) for an external token issuer. When set,
+    Onyx accepts an RS256 JWT in the `Authorization: Bearer` header and resolves the user from the token's email claim.
+    See [JWT Header Auth](/deployment/authentication/jwt) for the full behavior.
+  </Accordion>
+
   <Accordion title="Email Configuration">
     <Info>
 

--- a/docs.json
+++ b/docs.json
@@ -136,7 +136,8 @@
               "deployment/authentication/oauth",
               "deployment/authentication/oidc",
               "deployment/authentication/saml",
-              "deployment/authentication/sso_providers"
+              "deployment/authentication/sso_providers",
+              "deployment/authentication/jwt"
             ]
           },
           {


### PR DESCRIPTION
## What

Adds a documentation page for `JWT_PUBLIC_KEY_URL`, which lets an identity provider or API gateway
mint a JWT that Onyx accepts on the `Authorization: Bearer` header.

- `deployment/authentication/jwt.mdx` — new page under Authentication
- `deployment/configuration/configuration.mdx` — accordion for the variable, linking to the page
- `docs.json` — nav entry

## Why

The variable is deployed customer surface, but it was not in the docs. Self-hosted operators who
build against it had no written statement of what Onyx holds stable, and no reference for the
behavior around it. Prospects have asked us to confirm in writing that it is supported, or to name
the mechanism to build against instead. This is that mechanism, so the docs should say so.

## What the page commits to

The **Support and stability** section names the interface: the variable, the `Authorization: Bearer`
header, RS256, the accepted key formats, and the identity claim order. It cites the existing
external-dependency tests from #13738 as the control that keeps this behavior from regressing
silently. It does not invent a deprecation policy — the repo has none written down — so it promises
only that a future replacement is called out in the release notes with the mechanism that replaces
it.

## Verified against the code

Every claim is traced to `backend/onyx/auth/jwt.py` and `_check_for_saml_and_jwt` in
`backend/onyx/auth/users.py`:

- RS256 only; the URL serves JWKS or PEM, chosen by `Content-Type` or a leading `{`
- JWKS key selected by `kid`, then `x5t`, then the sole key; the cache clears and refetches once on
  a verification failure, so rotation needs no restart
- Identity claim order `email`, `preferred_username`, `upn`, normalized and lowercased
- JIT provisioning; inactive and non-web-login accounts rejected; the invite allowlist and
  `VALID_EMAIL_DOMAINS` still apply; `TRACK_EXTERNAL_IDP_EXPIRY` writes `exp` to the user's external
  IdP expiry

## Two caveats called out on the page

Please check that we are comfortable publishing both.

1. **`aud` and `iss` are not verified.** `verify_aud` is `False` and no issuer is passed, so any
   token the configured key signs is accepted. The page carries this as a Warning with the
   mitigation: publish a key that only signs tokens for Onyx.
2. **Precedence is session cookie, then JWT, then PAT / API key.** The JWT path runs first on the
   `Authorization` header. API keys keep working because a key is not a valid RS256 JWT and falls
   through. The page says this plainly rather than implying API keys are checked first.

## Checks

- `python scripts/format_docs.py --check` — all files correctly formatted
- `mintlify broken-links` — no broken links
- `docs.json` parses as valid JSON

## Edition audit (second commit)

Checked every claim on the page against the code for Community Edition versus Enterprise Edition.

**The feature is Community Edition.** `onyx/auth/jwt.py`, the `JWT_PUBLIC_KEY_URL` config, and
`_check_for_saml_and_jwt` all live in the MIT core, and none of them calls an EE implementation.
`TRACK_EXTERNAL_IDP_EXPIRY` is MIT as well. The page now says this, so readers do not assume a
license is needed.

Three corrections came out of the audit:

- The page said a provisioned user gets no elevated permissions. That is false on an empty instance,
  where the first user created becomes an admin on any login path, and false on Enterprise Edition,
  where emails in the default-admin list are made admins at creation (`get_default_admin_user_emails`
  returns `[]` on MIT). Both cases are now stated.
- Seat limits were missing. Just-in-time provisioning runs through `UserManager.create`, which calls
  `enforce_seat_limit_locked`. That resolves through `fetch_ee_implementation_or_noop`, so it is a
  no-op on MIT and a real check on Enterprise Edition — a login for an unknown user fails once the
  workspace is at its seat limit. Added as an Enterprise Edition behavior.
- SCIM is Enterprise Edition (`backend/ee/onyx/server/scim/`). The page offered it as a way to manage
  access without saying so. Now marked.
