### PR TITLE
docs: document interface language support

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -6,6 +6,32 @@ mode: "wide"
 rss: true
 ---
 
+<Update label="v4.7.0" description="August 27th, 2026" tags={["New Features"]}>
+
+  ## v4.7.0
+
+  Onyx's interface is now available in Spanish, Portuguese, French, and German, alongside English.
+
+  Thank you to our contributors for helping make this release possible!
+
+  ## Key Improvements
+
+  ### Interface Language
+
+  You can now use the Onyx interface in **Español**, **Português**, **Français**, or **Deutsch**,
+  in addition to English.
+  Choose your preferred language from the new **Language** dropdown on the
+  [General](https://docs.onyx.app/overview/core_features/general_settings)
+  tab of your User Settings (`/app/settings/general`) — language names are always shown in their native spelling,
+  regardless of which language is currently active.
+
+  ---
+
+  Our [GitHub Releases](https://github.com/onyx-dot-app/onyx/releases?utm_source=docs&utm_content=changelog)
+  page has the full list of changes and bug fixes for each release.
+
+</Update>
+
 <Update label="v4.4.0" description="July 21st, 2026" tags={["New Features", "Deployment Changes", "Bug Fixes"]}>
 
   ## v4.4.0

--- a/docs.json
+++ b/docs.json
@@ -34,6 +34,7 @@
               "overview/core_features/code_interpreter",
               "overview/core_features/image_generation",
               "overview/core_features/voice_mode",
+              "overview/core_features/general_settings",
               {
                 "group": "Craft",
                 "icon": "hammer",

--- a/overview/core_features/general_settings.mdx
+++ b/overview/core_features/general_settings.mdx
@@ -1,0 +1,32 @@
+---
+title: "General Settings"
+description: "Profile and interface preferences"
+icon: "gear"
+---
+
+## Overview
+
+The **General** tab of your User Settings page holds account-level preferences that apply across your Onyx experience,
+including your interface language.
+
+<img className="rounded-image" src="/assets/overview/GENERIC_PLACEHOLDER.png" alt="Onyx General Settings"/>
+
+## Interface Language
+
+Onyx's interface is available in:
+
+- English (default)
+- Español
+- Português
+- Français
+- Deutsch
+
+<Note>
+  Language names are always shown in their native spelling, regardless of which language is currently active,
+  so you can find your language even if you can't read the current interface text.
+</Note>
+
+To change your interface language, open **User Settings > General** (`/app/settings/general`)
+and select a language from the **Language** dropdown.
+
+<img className="rounded-image" src="/assets/overview/GENERIC_PLACEHOLDER.png" alt="Onyx Language dropdown"/>


### PR DESCRIPTION
## Summary
- Add a new **General Settings** page (`overview/core_features/general_settings.mdx`) under the Overview → Core Features nav, documenting the `/app/settings/general` tab and its new **Language** dropdown (English, Español, Português, Français, Deutsch).
- Add a `v4.7.0` changelog entry announcing interface language support.

## Test plan
- [x] `python scripts/format_docs.py --check` passes (no new formatting issues introduced)
- [x] `docs.json` validated as well-formed JSON
- [ ] Screenshots are placeholders (`GENERIC_PLACEHOLDER.png`) — swap in real screenshots of the General settings tab and Language dropdown before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)