### PR TITLE
docs: rename SANDBOX_API_SERVER_URL to ONYX_SERVER_URL and document v4.6 deployment settings

### DIFF
--- a/deployment/configuration/configuration.mdx
+++ b/deployment/configuration/configuration.mdx
@@ -145,6 +145,9 @@ the vector database. The key environment variables that drive this are:
     A subset of common configuration options are provided for you. You can add more environment variables (listed below)
     to these sections.
 
+    To use external model servers, set `MODEL_SERVER_HOST` and `INDEXING_MODEL_SERVER_HOST` in `configMap`.
+    The chart then skips its own defaults for those values (chart 0.8.10 or later).
+
 ### Deploying Onyx Lite with Helm
 
     Onyx Lite is deployed by providing the values-lite.yaml file when installing the Helm chart.
@@ -279,7 +282,11 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
 
     `SANDBOX_BACKEND`: Craft sandbox backend. Valid values are `docker` and `kubernetes`. Defaults to `kubernetes`.
 
-    `SANDBOX_API_SERVER_URL`: Onyx base URL reachable from inside Craft sandboxes. Required for Craft deployments.
+    `ONYX_SERVER_URL`: Full Onyx API base URL reachable from inside Craft sandboxes,
+    including any `/api` path prefix (for example `https://onyx.example.com/api`,
+    or `http://<release>-api-service.<ns>.svc.cluster.local:8080` with no prefix). Required for Helm Craft deployments.
+    Docker Compose defaults it to the private `onyx-craft-api` alias.
+    Replaces `SANDBOX_API_SERVER_URL` (renamed in `v4.5.0`).
 
     `SANDBOX_IDLE_TIMEOUT_SECONDS`: Idle timeout before sandbox sleep or cleanup. Defaults to `3600`.
 
@@ -432,6 +439,21 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
     `DB_READONLY_USER`: Read-only database user
 
     `DB_READONLY_PASSWORD`: Read-only database password
+
+    `POSTGRES_SSLMODE`: libpq SSL mode (`disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`).
+    Ignored when `USE_IAM_AUTH` is set.
+
+    `POSTGRES_SSLROOTCERT`: Path to the CA certificate used to verify the server (`verify-ca` / `verify-full`).
+
+    `POSTGRES_SSLCERT`: Path to the client certificate for mutual TLS
+
+    `POSTGRES_SSLKEY`: Path to the client private key for mutual TLS
+
+    `POSTGRES_SSLKEY_PASSWORD`: Passphrase for `POSTGRES_SSLKEY`, if encrypted
+
+    In Helm, set `postgresTls.enabled:
+    true` with `postgresTls.caSecretName` or `postgresTls.caConfigMapName` to mount a CA certificate and configure these
+    settings on every backend workload.
   </Accordion>
 
   <Accordion title="Redis Configuration">
@@ -458,6 +480,18 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
     `REDIS_SSL_CERT_REQS`: SSL certificate requirements
 
     `REDIS_SSL_CA_CERTS`: SSL CA certificates
+
+    `REDIS_SSL_CERTFILE`: Client certificate for mutual TLS (set together with `REDIS_SSL_KEYFILE`)
+
+    `REDIS_SSL_KEYFILE`: Client private key for mutual TLS
+
+    `REDIS_SENTINEL_HOSTS`: Comma-separated `host:port` list of Redis Sentinel nodes. When set,
+    Onyx and Celery discover the current master through Sentinel instead of `REDIS_HOST` / `REDIS_PORT`.
+    Cannot be combined with `USE_REDIS_IAM_AUTH`.
+
+    `REDIS_SENTINEL_MASTER_NAME`: Sentinel master name. Defaults to `mymaster`.
+
+    `REDIS_SENTINEL_PASSWORD`: Password for the Sentinel nodes, if they require separate auth from the data nodes.
   </Accordion>
 
   <Accordion title="Vespa Configuration">
@@ -498,6 +532,9 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
     `CELERY_WORKER_DOCFETCHING_CONCURRENCY`: Document fetching worker concurrency
 
     `CELERY_WORKER_KG_PROCESSING_CONCURRENCY`: Knowledge graph processing worker concurrency
+
+    `CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT`: Per-connector external group sync lock TTL in seconds. Defaults to `300`.
+    Raise it if group syncs run long, so periodic re-dispatches do not start duplicate syncs.
   </Accordion>
 
   <Accordion title="Rate Limiting">
@@ -650,6 +687,9 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
     `LOG_POSTGRES_LATENCY`: Log PostgreSQL latency
 
     `LOG_POSTGRES_CONN_COUNTS`: Log PostgreSQL connection counts
+
+    `LOG_THIRD_PARTY_DEBUG`: Third-party libraries (LiteLLM, httpcore, botocore)
+    are capped at `INFO` even when `LOG_LEVEL=debug`. Set to `true` to let them log at `LOG_LEVEL`.
   </Accordion>
 
   <Accordion title="Image Processing Configuration">
@@ -674,6 +714,12 @@ Read [Deploying Craft](/deployment/local/craft) before enabling Craft in self-ho
     `IMAGE_SUMMARIZATION_SYSTEM_PROMPT`: System prompt for image summarization
 
     `IMAGE_SUMMARIZATION_USER_PROMPT`: User prompt for image summarization
+
+    `IMAGE_SUMMARIZATION_TIMEOUT`: Timeout in seconds for image summarization LLM calls during indexing.
+    Defaults to `300`.
+
+    `CONTEXTUAL_RAG_LLM_TIMEOUT`: Timeout in seconds for contextual RAG summary LLM calls during indexing.
+    Defaults to `180`.
   </Accordion>
 
   <Accordion title="File Storage Configuration">

--- a/deployment/local/craft.mdx
+++ b/deployment/local/craft.mdx
@@ -35,7 +35,8 @@ Both deployment paths require:
 
 - A full Onyx deployment with the vector database and background workers. Craft does not run on Onyx Lite.
 - A supported Onyx release and matching application and sandbox image versions.
-- An Onyx URL that the sandbox runtime can reach, configured as `SANDBOX_API_SERVER_URL`.
+- An Onyx API URL that the sandbox runtime can reach, configured as `ONYX_SERVER_URL` (Docker Compose sets a
+  working default; Helm requires it).
 - Capacity for a sandbox per active Craft user.
 - An Anthropic, OpenAI, or OpenRouter provider configured after deployment.
 

--- a/deployment/local/craft_kubernetes.mdx
+++ b/deployment/local/craft_kubernetes.mdx
@@ -15,7 +15,7 @@ RBAC, egress proxy, NetworkPolicies, and Scheduled Task worker used by Craft.
 - A URL that sandbox pods can use to reach the Onyx API
 
 The chart fails the install or upgrade when Craft is enabled on an older Kubernetes version,
-when the sandbox backend is not `kubernetes`, when `SANDBOX_API_SERVER_URL` is empty,
+when the sandbox backend is not `kubernetes`, when `ONYX_SERVER_URL` is empty,
 or when sandbox push authentication is not configured.
 
 ## Prepare sandbox nodes
@@ -69,7 +69,7 @@ merge these entries under the existing keys rather than adding a second block.
 configMap:
   ENABLE_CRAFT: "true"
   SANDBOX_BACKEND: "kubernetes"
-  SANDBOX_API_SERVER_URL: "https://onyx.example.com"
+  ONYX_SERVER_URL: "https://onyx.example.com/api"
 
 auth:
   sandboxPushSecret:
@@ -77,8 +77,15 @@ auth:
     existingSecret: "onyx-sandbox-push-secret"
 ```
 
-`SANDBOX_API_SERVER_URL` can be the public Onyx URL or a cluster-internal URL.
+`ONYX_SERVER_URL` is the full API base URL, path prefix included.
+It can be the public Onyx URL through your proxy (`https://onyx.example.com/api`)
+or the cluster-internal API Service (`http://<release>-api-service.<namespace>.svc.cluster.local:8080`, no prefix).
 Use a scheme and hostname that resolve from the sandbox proxy and route to the Onyx API.
+A public URL without its `/api` prefix fails at sandbox provisioning with a corrected value.
+
+<Note>
+  Before `v4.5.0` this setting was named `SANDBOX_API_SERVER_URL`. Rename it in your values file when upgrading.
+</Note>
 
 Install or upgrade Onyx with your complete deployment values:
 
@@ -129,6 +136,23 @@ Use `sandboxPod.nodeSelector`, `sandboxPod.tolerations`, and `sandboxPod.affinit
 The proxy and Scheduled Task worker have separate resource settings under `sandboxProxy.resources` and
 `celery_worker_scheduled_tasks.resources`.
 
+### Pre-pull the sandbox image
+
+When Craft is enabled, the chart runs a DaemonSet (`sandboxImagePrepull`)
+that pulls the sandbox image onto every sandbox node ahead of time,
+so the first sandbox on a node does not wait for the image pull.
+It is on by default and uses about 3.3 GB of disk per sandbox node.
+
+```yaml
+sandboxImagePrepull:
+  enabled: true
+  priorityClassName: ""
+  updateMaxUnavailable: "25%"
+```
+
+Set `enabled: false` on nodes without that disk headroom. Pin `global.version` to an immutable tag when pre-pulling;
+a mutable tag such as `latest` stays at whichever digest the node pulled first.
+
 ## Verify the deployment
 
 Confirm the proxy, sandbox template, and Scheduled Task worker exist:
@@ -168,7 +192,7 @@ Most clusters work with the chart defaults. Two cluster layouts require addition
 <AccordionGroup>
   <Accordion title="Helm rejects the Craft configuration">
     Read the render error first. Confirm Kubernetes 1.33 or later, `SANDBOX_BACKEND: "kubernetes"`,
-    a non-empty `SANDBOX_API_SERVER_URL`, and `auth.sandboxPushSecret.enabled: true` with a populated Secret.
+    a non-empty `ONYX_SERVER_URL`, and `auth.sandboxPushSecret.enabled: true` with a populated Secret.
   </Accordion>
 
   <Accordion title="Sandbox pods remain Pending">
@@ -184,7 +208,7 @@ Most clusters work with the chart defaults. Two cluster layouts require addition
   </Accordion>
 
   <Accordion title="Craft cannot reach the Onyx API">
-    Verify `SANDBOX_API_SERVER_URL`, DNS, TLS trust, and routing from the proxy.
+    Verify `ONYX_SERVER_URL` (including the `/api` prefix on public URLs), DNS, TLS trust, and routing from the proxy.
     Do not point it at a Service name from another cluster or an address the proxy cannot resolve.
   </Accordion>
 

--- a/developers/guides/llm_gateway.mdx
+++ b/developers/guides/llm_gateway.mdx
@@ -241,6 +241,19 @@ Those limits apply before the gateway sends a generation request to a model prov
 
 <img className="rounded-image" src="/assets/developers/llm_gateway_spending_limits.png" alt="Onyx Admin Panel controls for global, user, and group spending limits"/>
 
+## Native passthrough
+
+Requests that resolve to an Anthropic provider or a true OpenAI model are proxied natively to the provider.
+Hosted and server tools, extended thinking, and fine-grained streaming pass through unchanged.
+Requests for other providers are translated through the OpenAI-compatible path.
+
+Self-hosted administrators can turn passthrough off with these environment variables on the API server:
+
+- `ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED=false`: send Anthropic-backed providers through the translation path.
+- `OPENAI_GATEWAY_PASSTHROUGH_ENABLED=false`: send true-OpenAI models through the translation path.
+
+Both default to on.
+
 ## Common errors
 
 | Error | What to check |


### PR DESCRIPTION
## Summary

Companion to #446 (v4.6.0 changelog) — updates the reference/config docs for settings that changed or landed between v4.5 and v4.6.

**Craft env var rename (v4.5.0):** `SANDBOX_API_SERVER_URL` → `ONYX_SERVER_URL` in `configuration.mdx`, `craft.mdx`, `craft_kubernetes.mdx`. This is not a pure rename: the new value is the *full API base URL including path prefix*, so public URLs need `/api` (`https://onyx.example.com/api`) while the in-cluster Service does not (`http://<release>-api-service.<ns>.svc.cluster.local:8080`). Helm fails validation without `configMap.ONYX_SERVER_URL`; Docker Compose defaults to the private `onyx-craft-api` alias. Added an upgrade note for people carrying the old key in their values file.

**New in 4.6, previously undocumented:**
- `deployment/configuration/configuration.mdx`: `IMAGE_SUMMARIZATION_TIMEOUT` (300), `CONTEXTUAL_RAG_LLM_TIMEOUT` (180), `CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT` (300), `LOG_THIRD_PARTY_DEBUG`, Postgres TLS (`POSTGRES_SSLMODE` / `SSLROOTCERT` / `SSLCERT` / `SSLKEY` / `SSLKEY_PASSWORD` + Helm `postgresTls`), Redis mTLS (`REDIS_SSL_CERTFILE` / `REDIS_SSL_KEYFILE`) and Sentinel (`REDIS_SENTINEL_HOSTS` / `MASTER_NAME` / `PASSWORD`), Helm external model-server override via `MODEL_SERVER_HOST` / `INDEXING_MODEL_SERVER_HOST`.
- `deployment/local/craft_kubernetes.mdx`: Helm `sandboxImagePrepull` DaemonSet section.
- `developers/guides/llm_gateway.mdx`: native Anthropic/OpenAI passthrough and the `ANTHROPIC_GATEWAY_PASSTHROUGH_ENABLED` / `OPENAI_GATEWAY_PASSTHROUGH_ENABLED=false` kill switches.

Deliberately skipped `FORCED_DOCUMENT_SET_NAMES` (marked temporary in source).

Defaults and semantics were taken from `backend/onyx/configs/*.py`, `deployment/docker_compose/env.template`, and the Helm chart templates at the v4.6 tag. `prek run --all-files` (format_docs, prettier, broken links, ripsecrets) passes.


Link to Devin session: https://app.devin.ai/sessions/e59a1ab938314946b54fe2e977de1ba7
Open in Devin Desktop: https://app.devin.ai/desktop/session/e59a1ab938314946b54fe2e977de1ba7?variant=devin
Requested by: @rohoswagger