### PR TITLE
docs(search): document the search APIs, refresh send-chat-message

### DIFF
--- a/developers/api_reference/chat/handle_send_chat_message.mdx
+++ b/developers/api_reference/chat/handle_send_chat_message.mdx
@@ -8,3 +8,9 @@ openapi: "POST /chat/send-chat-message"
   A limited [Personal Access Token](/developers/overview#personal-access-tokens) needs the Chat &mdash; Write scope.
   A service account in no group also holds it. Anonymous users can call this when anonymous access is enabled.
 </Info>
+
+<Note>
+  **Multi-model requests must stream.** Passing `llm_overrides` with more than one entry runs the models in parallel and
+  requires `stream=true`; combining it with `stream=false` returns `400 {"error_code": "INVALID_INPUT"}`.
+  A single-entry `llm_overrides` list is ignored &mdash; use `llm_override` for an ordinary single-model override.
+</Note>

--- a/developers/api_reference/openapi.json
+++ b/developers/api_reference/openapi.json
@@ -4884,6 +4884,217 @@
         }
       }
     },
+    "/search": {
+      "post": {
+        "summary": "Search",
+        "operationId": "search",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["public"],
+        "description": "Run Onyx's internal search and get back ranked document sections, with no LLM answer generated.\n\nThis is the same multi-stage retrieval pipeline the chat Search action uses: query expansion, hybrid retrieval, reranking and section merging. Results are ordered most relevant first and are always filtered by the calling user's document permissions."
+      }
+    },
+    "/search/send-search-message": {
+      "post": {
+        "summary": "Handle Send Search Message",
+        "description": "Executes a search query with optional streaming.\n\nIf hybrid_alpha is unset and ONYX_SEARCH_UI_USES_OPENSEARCH_KEYWORD_SEARCH\nis True, executes pure keyword search.\n\nReturns:\n    StreamingResponse with SSE if stream=True, otherwise SearchFullResponse.",
+        "operationId": "handle_send_search_message",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendSearchQueryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "If `stream=true`, returns `text/event-stream`.\nIf `stream=false` (the default), returns `application/json` (SearchFullResponse).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchFullResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "stream": {
+                    "summary": "Stream of NDJSON search packets",
+                    "value": "string"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["public"]
+      }
+    },
+    "/search/search-history": {
+      "get": {
+        "summary": "Get Search History",
+        "description": "Fetch past search queries for the authenticated user.\n\nArgs:\n    limit: Maximum number of queries to return (default 100)\n    filter_days: Only return queries from the last N days (optional)\n\nReturns:\n    SearchHistoryResponse with list of search queries, ordered by most recent first.",
+        "operationId": "get_search_history",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Maximum number of queries to return, from 1 to 1000."
+          },
+          {
+            "name": "filter_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Filter Days"
+            },
+            "description": "Only return queries from the last N days. Omit for no time limit."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchHistoryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["public"]
+      }
+    },
+    "/search/search-flow-classification": {
+      "post": {
+        "summary": "Search Flow Classification",
+        "operationId": "search_flow_classification",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchFlowClassificationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchFlowClassificationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["public"],
+        "description": "Classify whether a query should be answered by search or by chat. This powers the query bar in the Onyx Search UI.\n\nQueries longer than 200 characters are classified as a chat flow without calling an LLM. If classification fails, the endpoint falls back to `is_search_flow: false` rather than erroring."
+      }
+    },
     "/admin/token-rate-limits/global": {
       "get": {
         "tags": ["public"],
@@ -8421,8 +8632,8 @@
           "system",
           "user",
           "assistant",
-          "tool_call",
-          "tool_call_response"
+          "tool_call_response",
+          "user_reminder"
         ],
         "title": "MessageType"
       },
@@ -12258,6 +12469,612 @@
         "required": ["tool_name", "tool_arguments", "tool_result"],
         "title": "ToolCallResponse",
         "description": "Tool call with full details for non-streaming response."
+      },
+      "ChatMinimalTextMessage": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "message_type": {
+            "$ref": "#/components/schemas/MessageType"
+          }
+        },
+        "type": "object",
+        "required": ["message", "message_type"],
+        "title": "ChatMinimalTextMessage"
+      },
+      "SearchDocWithContent": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "chunk_ind": {
+            "type": "integer",
+            "title": "Chunk Ind"
+          },
+          "semantic_identifier": {
+            "type": "string",
+            "title": "Semantic Identifier"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          },
+          "blurb": {
+            "type": "string",
+            "title": "Blurb"
+          },
+          "source_type": {
+            "$ref": "#/components/schemas/DocumentSource"
+          },
+          "boost": {
+            "type": "integer",
+            "title": "Boost"
+          },
+          "hidden": {
+            "type": "boolean",
+            "title": "Hidden"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "type": "object",
+            "title": "Metadata"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "is_relevant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Relevant"
+          },
+          "relevance_explanation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relevance Explanation"
+          },
+          "match_highlights": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Match Highlights"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "primary_owners": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Owners"
+          },
+          "secondary_owners": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secondary Owners"
+          },
+          "is_internet": {
+            "type": "boolean",
+            "title": "Is Internet",
+            "default": false
+          },
+          "file_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Id"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "chunk_ind",
+          "semantic_identifier",
+          "blurb",
+          "source_type",
+          "boost",
+          "hidden",
+          "metadata",
+          "match_highlights",
+          "content"
+        ],
+        "title": "SearchDocWithContent"
+      },
+      "SearchFlowClassificationRequest": {
+        "properties": {
+          "user_query": {
+            "type": "string",
+            "title": "User Query",
+            "description": "The query to classify."
+          }
+        },
+        "type": "object",
+        "required": ["user_query"],
+        "title": "SearchFlowClassificationRequest"
+      },
+      "SearchFlowClassificationResponse": {
+        "properties": {
+          "is_search_flow": {
+            "type": "boolean",
+            "title": "Is Search Flow",
+            "description": "True when the query looks like a search for documents, false when it should be sent to chat."
+          }
+        },
+        "type": "object",
+        "required": ["is_search_flow"],
+        "title": "SearchFlowClassificationResponse"
+      },
+      "SearchFullResponse": {
+        "properties": {
+          "all_executed_queries": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "All Executed Queries",
+            "description": "Every query that was run, starting with the original. Contains more than one entry only when `run_query_expansion` was set."
+          },
+          "search_docs": {
+            "items": {
+              "$ref": "#/components/schemas/SearchDocWithContent"
+            },
+            "type": "array",
+            "title": "Search Docs",
+            "description": "Matched sections, most relevant first."
+          },
+          "doc_selection_reasoning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Doc Selection Reasoning",
+            "description": "Reserved for the LLM's document-selection reasoning. Not currently populated \u2014 always `null` on this endpoint."
+          },
+          "llm_selected_doc_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Selected Doc Ids",
+            "description": "Document ids the LLM picked out of `search_docs`. `null` when LLM selection was not requested or failed, an empty list when it ran and chose nothing."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error",
+            "description": "Set when the search failed partway through; the other fields hold whatever was gathered before the failure."
+          }
+        },
+        "type": "object",
+        "required": ["all_executed_queries", "search_docs"],
+        "title": "SearchFullResponse"
+      },
+      "SearchHistoryResponse": {
+        "properties": {
+          "search_queries": {
+            "items": {
+              "$ref": "#/components/schemas/SearchQueryResponse"
+            },
+            "type": "array",
+            "title": "Search Queries"
+          }
+        },
+        "type": "object",
+        "required": ["search_queries"],
+        "title": "SearchHistoryResponse"
+      },
+      "SearchQueryResponse": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "title": "Query",
+            "description": "The query as the user typed it."
+          },
+          "query_expansions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Query Expansions",
+            "description": "Extra keyword queries generated for this search, or `null` when expansion was not run."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "When the query was run."
+          }
+        },
+        "type": "object",
+        "required": ["query", "query_expansions", "created_at"],
+        "title": "SearchQueryResponse"
+      },
+      "SearchRequest": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Query",
+            "description": "The query to search for."
+          },
+          "sources": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DocumentSource"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sources",
+            "description": "Restrict results to these connector source types."
+          },
+          "document_sets": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Document Sets",
+            "description": "Restrict results to documents in these document sets, by name."
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags",
+            "description": "Restrict results to documents carrying all of these metadata tags."
+          },
+          "time_cutoff": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Cutoff",
+            "description": "ISO 8601 timestamp. Only documents updated on or after this moment are returned. Timestamps without a timezone are treated as UTC."
+          },
+          "persona_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Persona Id",
+            "description": "Search as this Agent: its document sets, attached documents and search start date are applied on top of the other filters, and its LLM is used unless `provider`/`model` say otherwise."
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider",
+            "description": "Name of the LLM provider to use for query expansion and section selection. Must be sent together with `model`, and the caller must have access to the provider."
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "Model to use from `provider`. Must be sent together with `provider`."
+          },
+          "skip_query_expansion": {
+            "type": "boolean",
+            "title": "Skip Query Expansion",
+            "default": false,
+            "description": "When true, the query is run as written instead of being rewritten and expanded first."
+          },
+          "message_history": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ChatMinimalTextMessage"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message History",
+            "description": "Preceding conversation turns, used to interpret a query that depends on earlier context. Defaults to `query` on its own."
+          }
+        },
+        "type": "object",
+        "required": ["query"],
+        "title": "SearchRequest"
+      },
+      "SearchResponse": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "type": "array",
+            "title": "Results"
+          }
+        },
+        "type": "object",
+        "required": ["results"],
+        "title": "SearchResponse"
+      },
+      "SearchResult": {
+        "properties": {
+          "citation_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Citation Id",
+            "description": "1-based index of the source document. Several results share one `citation_id` when the search returned multiple non-overlapping sections of the same document."
+          },
+          "title": {
+            "type": "string",
+            "title": "Title",
+            "description": "Document title."
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Full text of the matched section."
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link",
+            "description": "Link to the source document, when the connector provides one."
+          },
+          "source_type": {
+            "type": "string",
+            "title": "Source Type",
+            "description": "Connector source type the document came from."
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "When the document was last updated, when the connector provides it."
+          }
+        },
+        "type": "object",
+        "required": [
+          "citation_id",
+          "title",
+          "content",
+          "link",
+          "source_type",
+          "updated_at"
+        ],
+        "title": "SearchResult"
+      },
+      "SendSearchQueryRequest": {
+        "properties": {
+          "search_query": {
+            "type": "string",
+            "title": "Search Query",
+            "description": "The query to search for."
+          },
+          "filters": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BaseFilters"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Restrict which documents are searched. All fields are optional and combine with AND."
+          },
+          "num_docs_fed_to_llm_selection": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Num Docs Fed To Llm Selection",
+            "description": "When set to 1 or more, the top N merged sections are handed to an LLM that picks the most relevant ones, and their document ids come back in `llm_selected_doc_ids`. Omit it (or send `null`) to skip LLM selection and the extra LLM call it costs."
+          },
+          "run_query_expansion": {
+            "type": "boolean",
+            "title": "Run Query Expansion",
+            "default": false,
+            "description": "When true, an LLM generates extra keyword queries from `search_query`. Every query runs in parallel and the results are merged with weighted reciprocal-rank fusion, with the original query weighted twice as heavily as each expansion. The queries that actually ran come back in `all_executed_queries`. Expansion failures are non-fatal: the original query still runs on its own."
+          },
+          "num_hits": {
+            "type": "integer",
+            "title": "Num Hits",
+            "default": 30,
+            "description": "Maximum number of merged sections to return."
+          },
+          "hybrid_alpha": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hybrid Alpha",
+            "description": "Balance between vector and keyword matching, from `0.0` (pure keyword) to `1.0` (pure vector). Leave unset to use the deployment's `HYBRID_ALPHA` (`0.5` by default) \u2014 except on deployments configured for OpenSearch keyword search, where leaving it unset runs a pure keyword search."
+          },
+          "include_content": {
+            "type": "boolean",
+            "title": "Include Content",
+            "default": false,
+            "description": "When true, each returned document carries the full text of the matched section in `content`. When false, `content` is `null` and only `blurb` is populated."
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": false,
+            "description": "When true, responds with a stream of newline-delimited JSON packets. When false (the default), returns the aggregated `SearchFullResponse`."
+          }
+        },
+        "type": "object",
+        "required": ["search_query"],
+        "title": "SendSearchQueryRequest"
       }
     },
     "securitySchemes": {

--- a/developers/api_reference/openapi.json
+++ b/developers/api_reference/openapi.json
@@ -289,7 +289,7 @@
       "post": {
         "tags": ["public"],
         "summary": "Handle Send Chat Message",
-        "description": "This endpoint is used to send a new chat message.\n\nArgs:\n    chat_message_req (SendMessageRequest): Details about the new chat message.\n        - When stream=True (default): Returns StreamingResponse with SSE\n        - When stream=False: Returns ChatFullResponse with complete data\n    request (Request): The current HTTP request context.\n    user (User | None): The current user, obtained via dependency injection.\n    _ (None): Rate limit check is run if user/group/global rate limits are enabled.\n\nReturns:\n    StreamingResponse | ChatFullResponse: Either streams or returns complete response.",
+        "description": "This endpoint is used to send a new chat message.\n\nArgs:\n    chat_message_req (SendMessageRequest): Details about the new chat message.\n        - When stream=True (default): Returns StreamingResponse with SSE\n        - When stream=False: Returns ChatFullResponse with complete data\n    request (Request): The current HTTP request context.\n    user (User): The current user, obtained via dependency injection.\n    _ (None): Rate limit check is run if user/group/global rate limits are enabled.\n\nReturns:\n    StreamingResponse | ChatFullResponse: Either streams or returns complete response.",
         "operationId": "handle_send_chat_message",
         "security": [
           {
@@ -308,10 +308,23 @@
         },
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "If `stream=true`, returns `text/event-stream`.\nIf `stream=false`, returns `application/json` (ChatFullResponse).",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/ChatFullResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                },
+                "examples": {
+                  "stream": {
+                    "summary": "Stream of NDJSON AnswerStreamPart's",
+                    "value": "string"
+                  }
+                }
               }
             }
           },
@@ -5375,17 +5388,25 @@
             ],
             "title": "Document Set"
           },
-          "time_cutoff": {
+          "created_at_range": {
             "anyOf": [
               {
-                "type": "string",
-                "format": "date-time"
+                "$ref": "#/components/schemas/TimeRange"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Time Cutoff"
+            ]
+          },
+          "updated_at_range": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TimeRange"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "tags": {
             "anyOf": [
@@ -5400,6 +5421,18 @@
               }
             ],
             "title": "Tags"
+          },
+          "time_cutoff": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Cutoff"
           }
         },
         "type": "object",
@@ -5472,7 +5505,6 @@
           "web",
           "google_drive",
           "gmail",
-          "requesttracker",
           "github",
           "gitbook",
           "gitlab",
@@ -5485,6 +5517,7 @@
           "productboard",
           "file",
           "coda",
+          "canvas",
           "notion",
           "zulip",
           "linear",
@@ -5494,6 +5527,7 @@
           "google_sites",
           "zendesk",
           "loopio",
+          "box",
           "dropbox",
           "sharepoint",
           "teams",
@@ -5520,8 +5554,11 @@
           "imap",
           "bitbucket",
           "testrail",
+          "braintrust",
+          "lumapps",
           "mock_connector",
-          "user_file"
+          "user_file",
+          "craft_file"
         ],
         "title": "DocumentSource"
       },
@@ -7711,6 +7748,17 @@
       },
       "LLMOverride": {
         "properties": {
+          "model_configuration_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Configuration Id"
+          },
           "model_provider": {
             "anyOf": [
               {
@@ -7743,10 +7791,22 @@
               }
             ],
             "title": "Temperature"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
           }
         },
         "type": "object",
-        "title": "LLMOverride"
+        "title": "LLMOverride",
+        "description": "Per-request LLM settings that override persona defaults.\n\nAll fields are optional \u2014 only the fields that differ from the persona's\nconfigured LLM need to be supplied. Used both over the wire (API requests)\nand for multi-model comparison, where one override is supplied per model.\n\nAttributes:\n    model_configuration_id: Exact model configuration to use. Preferred\n        over the name-based fields \u2014 provider display names are not\n        unique, so only the id routes unambiguously.\n    model_provider: LLM provider display name. When ``None``, the\n        persona's default provider is used.\n    model_version: Specific model version string (e.g. ``\"gpt-4o\"``).\n        When ``None``, the persona's default model is used.\n    temperature: Sampling temperature in ``[0, 2]``. When ``None``, the\n        persona's default temperature is used.\n    display_name: Human-readable label shown in the UI for this model,\n        e.g. ``\"GPT-4 Turbo\"``. Optional; falls back to ``model_version``\n        when not set."
       },
       "PaginatedReturn_FullUserSnapshot_": {
         "properties": {
@@ -8389,6 +8449,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",
@@ -8849,6 +8916,8 @@
           "api",
           "slackbot",
           "widget",
+          "discordbot",
+          "mobile",
           "unknown",
           "unset"
         ],
@@ -9119,6 +9188,23 @@
               }
             ],
             "title": "Project Id"
+          },
+          "incognito": {
+            "type": "boolean",
+            "title": "Incognito",
+            "default": false
+          },
+          "incognito_session_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Incognito Session Id"
           }
         },
         "type": "object",
@@ -9482,6 +9568,21 @@
               }
             ]
           },
+          "llm_overrides": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/LLMOverride"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Llm Overrides",
+            "description": "Two or three LLM overrides to run in parallel (multi-model mode), one entry per model. Requires `stream=true`: a request carrying more than one entry with `stream=false` is rejected with a 400 `INVALID_INPUT` error. A list with a single entry is ignored \u2014 use `llm_override` to change the model for an ordinary single-model request."
+          },
           "allowed_tool_ids": {
             "anyOf": [
               {
@@ -9529,6 +9630,21 @@
             "type": "boolean",
             "title": "Deep Research",
             "default": false
+          },
+          "mcp_headers": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Headers",
+            "description": "Headers forwarded to MCP tool calls made while answering this message, e.g. `{\"Authorization\": \"Bearer <user_jwt>\", \"X-User-ID\": \"user123\"}`. Use this to pass end-user credentials through to MCP servers that require them."
           },
           "origin": {
             "$ref": "#/components/schemas/MessageOrigin",
@@ -10126,7 +10242,7 @@
       },
       "ChatFileType": {
         "type": "string",
-        "enum": ["image", "document", "plain_text", "csv"],
+        "enum": ["image", "document", "plain_text", "tabular"],
         "title": "ChatFileType"
       },
       "LlmWebSearchResult": {
@@ -11421,6 +11537,17 @@
             "type": "boolean",
             "title": "Is Internet",
             "default": false
+          },
+          "file_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Id"
           }
         },
         "type": "object",
@@ -11953,6 +12080,184 @@
         "type": "object",
         "required": ["permissions", "is_manager", "managed_group_ids"],
         "title": "UserPermissionsResponse"
+      },
+      "ChatFullResponse": {
+        "properties": {
+          "answer": {
+            "type": "string",
+            "title": "Answer"
+          },
+          "answer_citationless": {
+            "type": "string",
+            "title": "Answer Citationless"
+          },
+          "pre_answer_reasoning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Answer Reasoning"
+          },
+          "tool_calls": {
+            "items": {
+              "$ref": "#/components/schemas/ToolCallResponse"
+            },
+            "type": "array",
+            "title": "Tool Calls",
+            "default": []
+          },
+          "top_documents": {
+            "items": {
+              "$ref": "#/components/schemas/SearchDoc"
+            },
+            "type": "array",
+            "title": "Top Documents"
+          },
+          "citation_info": {
+            "items": {
+              "$ref": "#/components/schemas/CitationInfo"
+            },
+            "type": "array",
+            "title": "Citation Info"
+          },
+          "message_id": {
+            "type": "integer",
+            "title": "Message Id"
+          },
+          "chat_session_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chat Session Id"
+          },
+          "incognito": {
+            "type": "boolean",
+            "title": "Incognito",
+            "default": false
+          },
+          "error_msg": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Msg"
+          }
+        },
+        "type": "object",
+        "required": [
+          "answer",
+          "answer_citationless",
+          "top_documents",
+          "citation_info",
+          "message_id"
+        ],
+        "title": "ChatFullResponse",
+        "description": "Complete non-streaming response with all available data."
+      },
+      "TimeRange": {
+        "properties": {
+          "start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          }
+        },
+        "type": "object",
+        "title": "TimeRange",
+        "description": "An inclusive [start, end] window; either bound may be None (open).\nNaive (timezone-less) bounds are treated as UTC."
+      },
+      "ToolCallResponse": {
+        "properties": {
+          "tool_name": {
+            "type": "string",
+            "title": "Tool Name"
+          },
+          "tool_arguments": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Tool Arguments"
+          },
+          "tool_result": {
+            "type": "string",
+            "title": "Tool Result"
+          },
+          "search_docs": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SearchDoc"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Search Docs"
+          },
+          "generated_images": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/GeneratedImage"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generated Images"
+          },
+          "pre_reasoning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Reasoning"
+          }
+        },
+        "type": "object",
+        "required": ["tool_name", "tool_arguments", "tool_result"],
+        "title": "ToolCallResponse",
+        "description": "Tool call with full details for non-streaming response."
       }
     },
     "securitySchemes": {

--- a/developers/api_reference/search/get_search_history.mdx
+++ b/developers/api_reference/search/get_search_history.mdx
@@ -1,0 +1,16 @@
+---
+title: "Get Search History"
+openapi: "GET /search/search-history"
+---
+
+<Info>
+  **Required permission:** Search &mdash; Read (`read:search`), which `basic` includes, so any signed-in user has it.
+  A limited [Personal Access Token](/developers/overview#personal-access-tokens) needs the Search &mdash; Read scope.
+</Info>
+
+<Note>
+  Returns only the calling user's own queries, most recent first,
+  and only those sent through [Handle Send Search Message](/developers/api_reference/search/handle_send_search_message)
+  &mdash; chat messages and `POST /search` calls are not recorded here. A `limit` outside 1&ndash;1000,
+  or a `filter_days` of zero or less, is rejected with `400`.
+</Note>

--- a/developers/api_reference/search/handle_send_search_message.mdx
+++ b/developers/api_reference/search/handle_send_search_message.mdx
@@ -1,0 +1,22 @@
+---
+title: "Handle Send Search Message"
+openapi: "POST /search/send-search-message"
+---
+
+<Info>
+  **Required permission:** Search &mdash; Read (`read:search`), which `basic` includes, so any signed-in user has it.
+  A limited [Personal Access Token](/developers/overview#personal-access-tokens) needs the Search &mdash; Read scope.
+</Info>
+
+<Note>
+  This is the endpoint behind the Onyx Search UI.
+  Unlike [`POST /chat/send-chat-message`](/developers/api_reference/chat/handle_send_chat_message),
+  `stream` defaults to `false` here, so the default response is the aggregated `SearchFullResponse`.
+  See [Search with the API](/developers/guides/search_api_guide) for the streaming packet format.
+</Note>
+
+<Warning>
+  Requires a vector database: deployments running with `DISABLE_VECTOR_DB` set (Onyx Lite) answer with `501`.
+  Every query from a signed-in user is recorded in that user's [search
+  history](/developers/api_reference/search/get_search_history).
+</Warning>

--- a/developers/api_reference/search/search.mdx
+++ b/developers/api_reference/search/search.mdx
@@ -1,0 +1,24 @@
+---
+title: "Search"
+openapi: "POST /search"
+---
+
+<Info>
+  **Required permission:** Search &mdash; Read (`read:search`), which `basic` includes, so any signed-in user has it.
+  A limited [Personal Access Token](/developers/overview#personal-access-tokens) needs the Search &mdash; Read scope.
+</Info>
+
+<Note>
+  This is the endpoint to reach for when you want Onyx's search results in your own application.
+  It runs the same retrieval pipeline as the Search action in chat and returns ranked document sections,
+  without spending an LLM call on writing an answer.
+  The endpoint behind the Onyx Search UI is [Handle Send Search
+  Message](/developers/api_reference/search/handle_send_search_message), which exposes keyword expansion,
+  LLM document selection and streaming instead.
+</Note>
+
+<Warning>
+  Results are always filtered by the calling user's document permissions,
+  so the same query run by two users can return different documents. A search needs a vector database:
+  deployments running with `DISABLE_VECTOR_DB` set (Onyx Lite) answer with `501`.
+</Warning>

--- a/developers/api_reference/search/search_flow_classification.mdx
+++ b/developers/api_reference/search/search_flow_classification.mdx
@@ -1,0 +1,16 @@
+---
+title: "Search Flow Classification"
+openapi: "POST /search/search-flow-classification"
+---
+
+<Info>
+  **Required permission:** Search &mdash; Read (`read:search`), which `basic` includes, so any signed-in user has it.
+  A limited [Personal Access Token](/developers/overview#personal-access-tokens) needs the Search &mdash; Read scope.
+</Info>
+
+<Note>
+  A helper for query bars that offer both search and chat:
+  it costs one small LLM call and answers whether a query reads like a document search. It is a routing hint,
+  not a guarantee &mdash; queries over 200 characters are called a chat flow without asking the LLM at all,
+  and a failed classification returns `is_search_flow: false` rather than an error.
+</Note>

--- a/developers/guides/chat_new_guide.mdx
+++ b/developers/guides/chat_new_guide.mdx
@@ -19,15 +19,17 @@ This guide was explain all of the parameters you can pass in to the API and prov
 | Parameter | Description |
 |-----------|-------------|
 | `message` | The user message to send to the Agent. |
-| `llm_override` | Pass an object to override the default LLM settings for this request. If `None`, you will get the default Onyx behavior. <br/><br/>You can pass or exclude any of the following fields: <br/>• `model_provider` <br/>• `model_version` <br/>• `temperature` <br/><br/>If you pass an invalid configuration (e.g., specifying `claude-sonnet-4.5` when the default `model_provider` is OpenAI), your request will fail. |
+| `llm_override` | Pass an object to override the default LLM settings for this request. If `None`, you will get the default Onyx behavior. <br/><br/>You can pass or exclude any of the following fields: <br/>• `model_configuration_id` – the exact model configuration to use. Preferred over the name-based fields, since provider display names are not unique <br/>• `model_provider` <br/>• `model_version` <br/>• `temperature` <br/>• `display_name` – label shown for the model in the UI; falls back to `model_version` <br/><br/>If you pass an invalid configuration (e.g., specifying `claude-sonnet-4.5` when the default `model_provider` is OpenAI), your request will fail. |
+| `llm_overrides` | Two or three `llm_override` objects to run in parallel (multi-model mode), one per model. <br/><br/>**Requires `stream=true`.** Sending more than one entry with `stream=false` fails with `400 {"error_code": "INVALID_INPUT"}`. A list with a single entry is ignored — use `llm_override` for an ordinary single-model request. |
 | `allowed_tool_ids` | Agents are created with a set of Actions they are allowed to invoke. You can further configure this set for your immediate interaction using this parameter. See the list of Actions and their IDs via the [GET /tool](/developers/api_reference/actions/list_tools) endpoint. Pass in an empty list to disable all Actions. Pass in `None` to allow all the Actions which are configured for the Agent. |
 | `forced_tool_id` | Force the Agent to use a specific Action for this request. The Agent may run other Actions before returning its final response, but it will be guaranteed to use this one. Leave empty to let the Agent decide which Actions to use. |
 | `file_descriptors` | A list of files to include along with your request. File IDs can be found via the [POST /user/projects/file/upload](/developers/api_reference/projects/upload_user_files) and the [GET /user/projects/file/{file_id}](/developers/api_reference/projects/get_user_file) endpoints. |
-| `search_filters` | Filters to narrow down the internal search results used by the Agent. All filter arguments are optional and can be combined: <br/><br/>• `source_type` – Source types like `web`, `slack`, `google_drive`, `confluence` <br/>• `document_set` – The name of the document sets to search within <br/>• `time_cutoff` – ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ` <br/>• `tags` – Format: `{"tag_key": "tag_value"}` |
+| `internal_search_filters` | Filters to narrow down the internal search results used by the Agent. All filter arguments are optional and can be combined: <br/><br/>• `source_type` – Source types like `web`, `slack`, `google_drive`, `confluence` <br/>• `document_set` – The name of the document sets to search within <br/>• `created_at_range` / `updated_at_range` – An inclusive window, `{"start": ..., "end": ...}`, in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. Either bound may be omitted to leave that side open; naive timestamps are treated as UTC <br/>• `tags` – A list of `{"tag_key": ..., "tag_value": ...}` objects <br/><br/>**Note:** `time_cutoff` is still accepted as a deprecated alias for the start of `updated_at_range`. |
 | `deep_research` | Enables Deep Research mode for this request. <br/><br/>**Note:** This mode consumes significantly more tokens, so be careful accessing it via the API. |
+| `mcp_headers` | Headers forwarded to MCP tool calls made while answering this message, e.g. `{"Authorization": "Bearer <user_jwt>"}`. Use this to pass end-user credentials through to MCP servers that require them. |
 | `parent_message_id` | The ID of the parent message in the chat history (primary-key for the previous message in the chat history tree). If not passed in, your new message is assumed to be sequentially after the last message. <br/><br/>**Warning:** If set to `None`, the chat history is reset and the new message is considered the first message in the chat history. |
 | `chat_session_id` | To continue an existing conversation, pass in the chat session ID where the message should be sent. If left blank, a new chat session will be created according to `chat_session_info`. |
-| `chat_session_info` | Details about the chat session which will be used for all messages in the session. Fields can be left blank to use defaults. <br/><br/>• `persona_id` – The ID of the Agent to use for the chat session <br/>• `project_id` – ID of a Project if the chat should be scoped to a Project |
+| `chat_session_info` | Details about the chat session which will be used for all messages in the session. Fields can be left blank to use defaults. <br/><br/>• `persona_id` – The ID of the Agent to use for the chat session <br/>• `project_id` – ID of a Project if the chat should be scoped to a Project <br/>• `incognito` – Start the session in incognito mode. The request is refused with an error when incognito is not available to the user, never silently downgraded to an ordinary chat <br/>• `incognito_session_id` – The session ID already used when uploading files, so the new session owns those files. Ignored unless `incognito` is true |
 | `stream` | If true, responds with an SSE stream of individual packets (same set used for the Onyx UI). Fields like the Answer, reasoning tokens, and iterative Tool Calls need to be pieced together from streamed tokens. |
 | `include_citations` | If true, responses will include citations for the sources used to generate the answer. |
 | `additional_context` | A string of extra context injected into the LLM call for this request. The context is passed to the model but is **not stored in the database** and will not appear in chat history.<br></br>Use this to supply ephemeral, request-scoped information (e.g. the user's current page URL, session metadata, or any runtime context) without polluting the persistent conversation history.<br></br>Pass `null` or omit the field to use no additional context. |
@@ -44,17 +46,19 @@ on GitHub for the complete list of packet types and their corresponding fields.
 
 ```python expandable
 class StreamingType(Enum):
-    """Enum defining all streaming packet types."""
+    """Enum defining all streaming packet types. This is the single source of truth for type strings."""
 
     SECTION_END = "section_end"
     STOP = "stop"
     TOP_LEVEL_BRANCHING = "top_level_branching"
     ERROR = "error"
+    CHAT_HEARTBEAT = "chat_heartbeat"
 
     MESSAGE_START = "message_start"
     MESSAGE_DELTA = "message_delta"
     SEARCH_TOOL_START = "search_tool_start"
     SEARCH_TOOL_QUERIES_DELTA = "search_tool_queries_delta"
+    SEARCH_TOOL_FILTER_DELTA = "search_tool_filter_delta"
     SEARCH_TOOL_DOCUMENTS_DELTA = "search_tool_documents_delta"
     OPEN_URL_START = "open_url_start"
     OPEN_URL_URLS = "open_url_urls"
@@ -65,11 +69,20 @@ class StreamingType(Enum):
     PYTHON_TOOL_START = "python_tool_start"
     PYTHON_TOOL_DELTA = "python_tool_delta"
     CUSTOM_TOOL_START = "custom_tool_start"
+    CUSTOM_TOOL_ARGS = "custom_tool_args"
     CUSTOM_TOOL_DELTA = "custom_tool_delta"
+    FILE_READER_START = "file_reader_start"
+    FILE_READER_RESULT = "file_reader_result"
     REASONING_START = "reasoning_start"
     REASONING_DELTA = "reasoning_delta"
     REASONING_DONE = "reasoning_done"
     CITATION_INFO = "citation_info"
+    TOOL_CALL_DEBUG = "tool_call_debug"
+    TOOL_CALL_ARGUMENT_DELTA = "tool_call_argument_delta"
+
+    MEMORY_TOOL_START = "memory_tool_start"
+    MEMORY_TOOL_DELTA = "memory_tool_delta"
+    MEMORY_TOOL_NO_ACCESS = "memory_tool_no_access"
 
     DEEP_RESEARCH_PLAN_START = "deep_research_plan_start"
     DEEP_RESEARCH_PLAN_DELTA = "deep_research_plan_delta"
@@ -77,6 +90,13 @@ class StreamingType(Enum):
     INTERMEDIATE_REPORT_START = "intermediate_report_start"
     INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta"
     INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs"
+
+    CODING_AGENT_START = "coding_agent_start"
+    CODING_AGENT_THINKING_DELTA = "coding_agent_thinking_delta"
+    CODING_AGENT_FINAL = "coding_agent_final"
+
+    BASH_TOOL_START = "bash_tool_start"
+    BASH_TOOL_DELTA = "bash_tool_delta"
 ```
 
 ### Non-streaming Response
@@ -98,6 +118,7 @@ class ChatFullResponse(BaseModel):
     # Metadata
     message_id: int
     chat_session_id: UUID | None = None
+    incognito: bool = False
     error_msg: str | None = None
 ```
 

--- a/developers/guides/search_api_guide.mdx
+++ b/developers/guides/search_api_guide.mdx
@@ -1,0 +1,224 @@
+---
+title: "Search with the API"
+description: "Query the Onyx index programmatically and get ranked documents back"
+icon: "magnifying-glass"
+---
+
+Onyx exposes two search endpoints, and which one you want depends on what you are building.
+
+| Endpoint | Use it when |
+|----------|-------------|
+| [`POST /search`](/developers/api_reference/search/search) | You want Onyx's search results inside your own application: RAG pipelines, agents, integrations, anything that needs ranked passages rather than an answer. Runs the same retrieval pipeline as the Search action in chat. |
+| [`POST /search/send-search-message`](/developers/api_reference/search/handle_send_search_message) | You are building a search interface. This is the endpoint behind the Onyx Search UI, and it adds keyword expansion, LLM document selection, streaming, and per-user search history. |
+
+Neither endpoint generates an answer. To have a model read the results and write a response,
+use [`POST /chat/send-chat-message`](/developers/api_reference/chat/handle_send_chat_message) instead.
+
+<Note>
+  Both endpoints search only the documents the calling user is allowed to see,
+  so the same query run by two users can return different results. Both also need a vector database:
+  on deployments running with `DISABLE_VECTOR_DB` set (Onyx Lite), they answer with `501`.
+</Note>
+
+## POST /search
+
+The request needs nothing but a query. Everything else narrows the search or changes how the query is interpreted.
+
+| Parameter | Description |
+|-----------|-------------|
+| `query` | The query to search for. Between 1 and 2048 characters. |
+| `sources` | Restrict results to these connector source types, e.g. `["slack", "google_drive"]`. |
+| `document_sets` | Restrict results to documents in these document sets, by name. |
+| `tags` | Restrict results to documents carrying all of these metadata tags, as a list of `{"tag_key": ..., "tag_value": ...}` objects. |
+| `time_cutoff` | ISO 8601 timestamp. Only documents updated on or after this moment are returned. Timestamps without a timezone are treated as UTC. |
+| `persona_id` | Search as an Agent. The Agent's document sets, attached documents and search start date apply on top of the other filters, and its LLM is used for query expansion. |
+| `provider` / `model` | The LLM used for query expansion and section selection. Both must be sent together, and the caller must have access to the provider. Defaults to the Agent's LLM, or the deployment default. |
+| `skip_query_expansion` | Run the query as written instead of rewriting and expanding it first. Useful when the query is already precise, or when you have your own expansion step. |
+| `message_history` | Preceding conversation turns, so a query like "what about last quarter?" can be interpreted in context. Defaults to `query` on its own. |
+
+Results come back most relevant first:
+
+```json
+{
+  "results": [
+    {
+      "citation_id": 1,
+      "title": "Q3 Planning",
+      "content": "Full text of the matched section...",
+      "link": "https://...",
+      "source_type": "google_drive",
+      "updated_at": "2026-08-14T09:31:00Z"
+    }
+  ]
+}
+```
+
+`citation_id` identifies the source document, not the result:
+several results share one `citation_id` when the search returned multiple non-overlapping sections of the same document.
+
+<CodeGroup>
+  ```python Python expandable
+  import requests
+
+  API_BASE_URL = "https://cloud.onyx.app/api"  # or your own domain
+  API_KEY = "YOUR_KEY_HERE"
+
+  response = requests.post(
+      f"{API_BASE_URL}/search",
+      headers={
+          "Authorization": f"Bearer {API_KEY}",
+          "Content-Type": "application/json",
+      },
+      json={
+          "query": "What is our parental leave policy?",
+          "sources": ["confluence", "google_drive"],
+      },
+  )
+
+  for result in response.json()["results"]:
+      print(f"[{result['citation_id']}] {result['title']} - {result['link']}")
+  ```
+
+  ```bash Shell expandable
+  #!/bin/bash
+
+  API_BASE_URL="https://cloud.onyx.app/api"  # or your own domain
+  API_KEY="YOUR_KEY_HERE"
+
+  curl -s -X POST "${API_BASE_URL}/search" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "query": "What is our parental leave policy?",
+      "sources": ["confluence", "google_drive"]
+    }' | jq '.results[] | {citation_id, title, link}'
+  ```
+</CodeGroup>
+
+## POST /search/send-search-message
+
+This endpoint takes a different set of parameters, aimed at a search interface rather than a retrieval pipeline.
+
+| Parameter | Description |
+|-----------|-------------|
+| `search_query` | The query to search for. |
+| `filters` | Restrict which documents are searched: `source_type`, `document_set`, `created_at_range` / `updated_at_range`, and `tags`. |
+| `num_hits` | Maximum number of merged sections to return. Defaults to 30. |
+| `hybrid_alpha` | Balance between vector and keyword matching, from `0.0` (pure keyword) to `1.0` (pure vector). Leave unset to use the deployment's `HYBRID_ALPHA`, which defaults to `0.5`. |
+| `include_content` | When true, each result carries the full text of the matched section in `content`. When false, `content` is `null` and only `blurb` is populated. |
+| `run_query_expansion` | Have an LLM generate extra keyword queries. Every query runs in parallel and the results are merged with weighted reciprocal-rank fusion, the original query counting twice as much as each expansion. |
+| `num_docs_fed_to_llm_selection` | Hand the top N sections to an LLM that picks the most relevant ones. Omit it to skip the extra LLM call. |
+| `stream` | Whether to stream packets as they are produced. **Defaults to `false`**, unlike the chat API. |
+
+Both LLM-backed options are optional and each costs an LLM call, so leave them off for a plain lexical/semantic search.
+Query expansion widens recall on short keyword queries;
+document selection narrows a long result list down to what actually answers the query,
+reporting its picks in `llm_selected_doc_ids` without dropping the other results.
+
+### Non-streaming response
+
+```json
+{
+  "all_executed_queries": ["parental leave policy"],
+  "search_docs": [
+    {
+      "document_id": "...",
+      "semantic_identifier": "Parental Leave",
+      "link": "https://...",
+      "blurb": "...",
+      "content": null,
+      "source_type": "confluence",
+      "score": 0.82
+    }
+  ],
+  "llm_selected_doc_ids": null,
+  "error": null
+}
+```
+
+`all_executed_queries` holds more than one entry only when `run_query_expansion` was set.
+`llm_selected_doc_ids` is `null` when LLM selection was not requested or failed,
+and an empty list when it ran and chose nothing. If the search fails partway through,
+`error` is set and the other fields hold whatever was gathered before the failure.
+
+### Streaming response
+
+With `stream: true` the response is `text/event-stream`, one JSON object per line, in this order:
+
+| Packet `type` | Contents |
+|---------------|----------|
+| `search_queries` | `all_executed_queries` &mdash; the original query plus any expansions. |
+| `search_docs` | `search_docs` &mdash; the ranked results. |
+| `llm_selected_docs` | `llm_selected_doc_ids`. Sent only when `num_docs_fed_to_llm_selection` was set. |
+| `search_error` | `error`. Sent in place of the remaining packets if the search fails. |
+
+<CodeGroup>
+  ```python Python expandable
+  import json
+
+  import requests
+
+  API_BASE_URL = "https://cloud.onyx.app/api"  # or your own domain
+  API_KEY = "YOUR_KEY_HERE"
+
+  with requests.post(
+      f"{API_BASE_URL}/search/send-search-message",
+      headers={
+          "Authorization": f"Bearer {API_KEY}",
+          "Content-Type": "application/json",
+      },
+      json={
+          "search_query": "What is our parental leave policy?",
+          "num_hits": 10,
+          "include_content": True,
+          "stream": True,
+      },
+      stream=True,
+  ) as response:
+      for line in response.iter_lines():
+          if not line:
+              continue
+          packet = json.loads(line)
+          if packet["type"] == "search_docs":
+              for doc in packet["search_docs"]:
+                  print(doc["semantic_identifier"], doc["link"])
+          elif packet["type"] == "search_error":
+              print("Search failed:", packet["error"])
+  ```
+
+  ```bash Shell expandable
+  #!/bin/bash
+
+  API_BASE_URL="https://cloud.onyx.app/api"  # or your own domain
+  API_KEY="YOUR_KEY_HERE"
+
+  curl -s -N -X POST "${API_BASE_URL}/search/send-search-message" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "search_query": "What is our parental leave policy?",
+      "num_hits": 10,
+      "include_content": true,
+      "stream": true
+    }' | jq -c 'select(.type == "search_docs") | .search_docs[] | {semantic_identifier, link}'
+  ```
+</CodeGroup>
+
+## Search history
+
+Every query sent through `POST /search/send-search-message` by a signed-in user is recorded,
+and [`GET /search/search-history`](/developers/api_reference/search/get_search_history)
+reads back that user's own queries, most recent first. Pass `limit` (1&ndash;1000, default 100)
+and `filter_days` to narrow the window. Queries sent to `POST /search` and to the chat API are not recorded there.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Guide: Send a Message to Onyx" icon="bolt" href="/developers/guides/chat_new_guide">
+    Have an Agent read the results and answer, instead of ranking documents
+  </Card>
+
+  <Card title="Guide: Use the Ingestion API" icon="upload" href="/developers/guides/index_files_ingestion_api">
+    Index your own documents so they show up in search
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -371,6 +371,7 @@
             "icon": "book-open",
             "pages": [
               "developers/guides/chat_new_guide",
+              "developers/guides/search_api_guide",
               "developers/guides/llm_gateway",
               "developers/guides/index_files_ingestion_api",
               "developers/guides/create_connector"
@@ -398,6 +399,10 @@
                 "group": "Search",
                 "icon": "magnifying-glass",
                 "pages": [
+                  "developers/api_reference/search/search",
+                  "developers/api_reference/search/handle_send_search_message",
+                  "developers/api_reference/search/get_search_history",
+                  "developers/api_reference/search/search_flow_classification",
                   "developers/api_reference/search/execute_web_search",
                   "developers/api_reference/search/execute_web_search_lite",
                   "developers/api_reference/search/execute_open_urls"


### PR DESCRIPTION
## What

Two commits:

1. **`docs(chat)`** — the published page for `POST /chat/send-chat-message` was generated from a stale OpenAPI snapshot. Regenerates the schemas reachable from that endpoint against the current backend, and fixes the same drift in the guide.
2. **`docs(search)`** — adds reference pages and a guide for the search APIs, which had none.

## Chat drift

| Schema | Change |
|---|---|
| `SendMessageRequest` | added `llm_overrides`, `mcp_headers` |
| `LLMOverride` | added `model_configuration_id`, `display_name` |
| `ChatSessionCreationRequest` | added `incognito`, `incognito_session_id` |
| `BaseFilters` | `time_cutoff` → `created_at_range`/`updated_at_range`; `time_cutoff` kept as the deprecated alias it now is |
| `ChatFullResponse`, `ToolCallResponse` | added — the 200 response referenced neither and was typed `{}` |
| 200 response | now documents `text/event-stream` vs `application/json` per `stream` |
| `ChatFileType` | `csv` → `tabular` |
| `MessageOrigin` | added `discordbot`, `mobile` |
| `DocumentSource` | added `canvas`, `box`, `braintrust`, `lumapps`, `craft_file`; dropped `requesttracker` |

`mock_llm_response` is deliberately left out: it raises unless `INTEGRATION_TESTS_MODE` is set, so it is not part of the public surface.

The guide carried the same drift plus one outright error — the filter parameter is `internal_search_filters`, not `search_filters`, so anyone copying it was silently getting unfiltered search. The `StreamingType` snippet is refreshed too, and the reference page gains a note for the `400 INVALID_INPUT` that multi-model requests hit with `stream=false` (FastAPI cannot generate it).

## Search APIs

Onyx has two search surfaces and the docs described neither:

| Endpoint | Source | Page |
|---|---|---|
| `POST /search` | `onyx/server/features/search/api.py` — full `SearchTool.run()` pipeline, built for programmatic consumers | `search/search.mdx` |
| `POST /search/send-search-message` | `ee/.../search_backend.py` — the Onyx Search UI backend | `search/handle_send_search_message.mdx` |
| `GET /search/search-history` | same router | `search/get_search_history.mdx` |
| `POST /search/search-flow-classification` | same router | `search/search_flow_classification.mdx` |

Plus `developers/guides/search_api_guide.mdx`: picking between the two, both parameter tables, the streaming packet order, and Python/shell samples.

## ⚠️ Needs a backend follow-up

None of the four search routes carry `tags=PUBLIC_API_TAGS`, so `transform_openapi_for_docs.py` filters them out — they were absent from `openapi.json` and will be absent again after the next regeneration. Their entries here were taken by hand from the full generated schema, so **they will drift until the backend tags them public**:

```python
@router.post("/send-search-message", response_model=None, tags=PUBLIC_API_TAGS, ...)
```

`send-search-message` also wants a real `response_model` or `responses=`; with `response_model=None`, FastAPI never registers `SearchFullResponse` or `SearchDocWithContent` (both had to be generated separately for this PR) and types the 200 as `{}`.

## Notes

- `stream` defaults to **`false`** on `send-search-message`, the opposite of `send-chat-message`. Called out on the page and in the guide.
- `doc_selection_reasoning` is in `SearchFullResponse` but `gather_search_stream` hardcodes it to `None`, so it is documented as not currently populated.
- All four search routes need `read:search`, which `basic` grants, and none appear in `PATH_PREFIX_MIN_TIER` — so despite living under `ee/`, they are not tier-gated and are not labelled Enterprise.
- `MessageType` was stale (`tool_call` removed, `user_reminder` added); `SearchRequest.message_history` references it, so it is refreshed here.

## Checks

Prettier (3.1.0, matching the pre-commit pin), `format_docs.py --check`, and the Mintlify broken-link check all pass. Every reference page's `openapi:` key resolves against the spec, and no `$ref` dangles — including at the intermediate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YHgZVvyM5degeZWXedbSn
